### PR TITLE
user can receive more emails after verification

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -28,9 +28,14 @@ const userSchema = new Schema({
 
     // Email verified status
     verified: { type: Boolean, default: false },
-
     // Email verification token
-    verificationToken: { type: String, required: false }
+    verificationToken: { type: String, required: false },
+    // Email verification token expiration
+    verificationTokenExpires: { type: Date, required: false },
+    // Number of verification emails sent
+    verificationEmailsSent: { type: Number, default: 0 },
+    // Timestamp of the last verification email sent
+    lastVerificationEmail: { type: Date, required: false },
 });
 
 // Middleware to set default username as authcate from email

--- a/frontend/src/app/shared/components/navbar/navbar.component.ts
+++ b/frontend/src/app/shared/components/navbar/navbar.component.ts
@@ -44,7 +44,7 @@ export class NavbarComponent {
   sidebarVisible: boolean = false;
 
   // Username for the sidebar
-  username: string = '';
+  username: string | undefined = '';
 
   // Saves the profile state
   profileState: 'logged out' | 'logged in' | 'signed out' | 'signed up' = 'signed out';
@@ -104,7 +104,7 @@ export class NavbarComponent {
 
       case 'logged in':
         this.messageService.add({ severity: 'success', summary: 'Logged in', detail: 'You are logged in!'});
-        this.username = 'jfer0043';
+        this.username = this.user?.username;
         break;
 
       case 'logged out':

--- a/frontend/src/app/shared/components/profile/profile.component.html
+++ b/frontend/src/app/shared/components/profile/profile.component.html
@@ -101,12 +101,16 @@
                     <p-floatLabel>
                         <input id="email" 
                             pInputText 
-                            class="{{ (isEmailInputValid || isEmailInputVerified) ? '' : 'ng-invalid ng-dirty' }}"
+                            class="{{ 
+                                ((isEmailInputValid || isEmailInputVerified) ? '' : 'ng-invalid ng-dirty') ||
+                                (isVerifyEmailSentCapped ? 'ng-invalid ng-dirty' : '')
+                            }}"
                             type="text" 
                             [(ngModel)]="inputEmail" 
                             (focus)="
                                 isEmailInputVerified = true;
                                 isEmailInputValid = true;
+                                isVerifyEmailSentCapped = false;
                             "
                             aria-labelledby="email-help"
                         />
@@ -118,6 +122,9 @@
                     @else if (!isEmailInputVerified) {
                         <small id="email-help" style="background-color: rgb(248, 113, 113);">User not verified, check your email.</small>
                     }
+                    @else if (isVerifyEmailSentCapped) {
+                        <small id="email-help" style="background-color: rgb(248, 113, 113);">Too many requests, please wait a while.</small>
+                    }
                 </div>
 
                 <!-- Password input-->
@@ -126,18 +133,20 @@
                         <p-password id="password" 
                             type="password" 
                             class="{{
-                                isPasswordsInputValid ? '' : 'ng-invalid ng-dirty'
+                                (isPasswordsInputValid ? '' : 'ng-invalid ng-dirty') ||
+                                (isVerifyEmailSentCapped ? 'ng-invalid ng-dirty' : '')
                             }}"
                             [toggleMask]="true" 
                             [feedback]="false"
                             [(ngModel)]="inputPassword"
                             (onFocus)="
                                 isPasswordsInputValid = true;
+                                isVerifyEmailSentCapped = false;
                             "
                         />
                         <label for="password">Password</label>
                     </p-floatLabel>
-                    @if (!isPasswordsInputValid) {
+                    @if (!isPasswordsInputValid && !isVerifyEmailSentCapped) {
                         <small id="password-help" style="background-color: rgb(248, 113, 113);">Invalid email or password</small>
                     }
                 </div>

--- a/frontend/src/app/shared/components/profile/profile.component.ts
+++ b/frontend/src/app/shared/components/profile/profile.component.ts
@@ -15,6 +15,7 @@ import { Subscription } from 'rxjs';
 import { User } from '../../models/user.model';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { TooltipModule } from 'primeng/tooltip';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-profile',
@@ -80,6 +81,8 @@ export class ProfileComponent implements OnInit, OnDestroy {
   isEmailInputValid: boolean = true;
   // Password input validity status
   isPasswordsInputValid: boolean = true;
+  // Email verification sent capped status
+  isVerifyEmailSentCapped: boolean = false;
 
   // Signing up and logging in state
   signingUp: boolean = false;
@@ -98,7 +101,10 @@ export class ProfileComponent implements OnInit, OnDestroy {
 
 
   // ! Injects AuthService
-  constructor (private authService: AuthService) { }
+  constructor (
+    private authService: AuthService,
+    private route: ActivatedRoute
+  ) { }
 
 
   // * Change title on initialisation
@@ -124,6 +130,12 @@ export class ProfileComponent implements OnInit, OnDestroy {
       next: (currentUser: User | null) => {
         // Store the current user
         this.user = currentUser;
+
+        if (this.user?.verified) {
+          this.state = 'logged in';
+          this.titleChangeEvent.emit('Profile');
+          this.stateChangeEvent.emit(this.state); 
+        }
 
         // Set the current username in the update username field in details page
         this.inputUpdateUsername = this.user?.username;
@@ -236,8 +248,10 @@ export class ProfileComponent implements OnInit, OnDestroy {
             this.signingUp = false;
             
             // If the error status is 400, the user already exists
-            if (error.status == 400)
+            if (error.status == 400) {
               this.isUserSignUpDuplicate = true;
+              this.createToast.emit({ severity: 'warn', summary: 'User already exists', detail: 'User already exists, please login.' });
+            }
 
             // ? Debug log error on signed up
             console.error('Profile | Sign up failed:', error.error);
@@ -311,13 +325,18 @@ export class ProfileComponent implements OnInit, OnDestroy {
           // Clear the password
           this.inputPassword = '';
 
-          // ? Check for 404 Not Found status code when user not found???
+          // Check for 429 Too Many Requests status code when user is rate limited
+          if (error.status == 429) {
+            this.isVerifyEmailSentCapped = true;
+            this.createToast.emit({ severity: 'warn', summary: '429 Too Many Requests', detail: "We have sent you too many emails at this time." });
+          }
 
           // Check for 403 Forbidden status code when user is not verified yet
           if (error.status == 403) {
             this.isEmailInputValid = true;
             this.isPasswordsInputValid = true;
             this.isEmailInputVerified = false;
+            this.createToast.emit({ severity: 'warn', summary: 'Email not verified', detail: 'Please verify your email before logging in' });
           }
 
           // ? Debug log error on login


### PR DESCRIPTION
- If user signs up then tried logging in without verifying their email. A new verification email will be sent to them with a new token. This has a five minute cooldown. Maximum of three emails can be sent per day in this way.
- A verification token will expire in 24 hours after being sent (maybe bump this down to 10 minutes in production).
- Fixed the bug where the user doesn't get logged in after verifying their email and going to the verified page.