### PR TITLE
sorting units

### DIFF
--- a/frontend/src/app/routes/unit-list/unit-list.component.html
+++ b/frontend/src/app/routes/unit-list/unit-list.component.html
@@ -12,6 +12,7 @@
             [editable]="true"
             placeholder="Sort By"
             [style]="{'border-radius': '3rem', 'width': '13rem', 'height': '2.25rem' }"
+            (onChange)="onSortByChange();"
             (onFocus)="isSortByFocused = true;"
             (onBlur)="isSortByFocused = false;"
           />
@@ -48,7 +49,7 @@
 </div>
 
 
-<!-- Loading spinner if loading -->
+<!-- Skeletons if loading -->
 @if (loading) {
   <div class="unit-list-container">
     <ng-container class="unit-card-wrapper">

--- a/frontend/src/app/routes/unit-list/unit-list.component.scss
+++ b/frontend/src/app/routes/unit-list/unit-list.component.scss
@@ -63,7 +63,7 @@ $padding: 40px;
         color: white;
         border-radius: 0.5rem;
         padding: 0.2rem 0.5rem;
-        font-size: 0.8rem;
+        font-size: 0.6rem;
         margin-left: 0.5rem;
     }
 }

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -121,11 +121,12 @@ export class ApiService {
    * @param {string} [search=''] The search query for filtering units
    * @returns {Observable<any[]>} An observable containing an array of filtered units
    */
-  getUnitsFilteredGET(offset: number, limit: number, search: string = ''): Observable<any[]> {
+  getUnitsFilteredGET(offset: number, limit: number, search: string = '', sort: string = 'Alphabetic'): Observable<any[]> {
     const params = {
       offset: offset.toString(),
       limit: limit.toString(),
       search,
+      sort
     }
 
     return this.http.get<any[]>(`${this.url}/units/filter`, { params });


### PR DESCRIPTION
- modified backend route 'GET Get Units Filtered' to get the units based on the sort option either 'Alphabetic', 'Most Reviews', 'Highest Overall', or 'Lowest Overall'.
- saving `sortBy` variable state in localStorage and retrieving this state on `ngOnInit()`.
- now when the sorting dropdown option is changed, the unit list will refresh and show units based on the sorting criterion, this is handled by the backend api endpoint mentioned before.
- made keybind helper badges smaller.