### PR TITLE
changed rating criteria names only in frontend

### DIFF
--- a/frontend/src/app/shared/components/review-card/review-card.component.html
+++ b/frontend/src/app/shared/components/review-card/review-card.component.html
@@ -134,7 +134,7 @@
                         <!-- Content Category -->
                         <div class="category content">
                             <!-- Category header -->
-                            <h6 class="category-header">Content</h6>
+                            <h6 class="category-header">Enjoyment</h6>
                             <!-- Circles for Content Rating -->
                             <div >
                                 <div class="circles">
@@ -155,7 +155,7 @@
                         <!-- Faculty Category -->
                         <div class="category faculty">
                             <!-- Category header -->
-                            <h6 class="category-header">Faculty</h6>
+                            <h6 class="category-header">Simplicity</h6>
                             <!-- Circles for faculty rating -->
                             <div class="circles">
                                 @for (circle of [1,2,3,4,5]; track $index) {
@@ -174,7 +174,7 @@
                         <!-- Relevancy Category -->
                         <div class="category relevancy">
                             <!-- Category header -->
-                            <h6 class="category-header">Relevancy</h6>
+                            <h6 class="category-header">Usefulness</h6>
                             <!-- Circles for relevancy rating -->
                             <div class="circles">
                                 @for (circle of [1,2,3,4,5]; track $index) {

--- a/frontend/src/app/shared/components/unit-review-header/unit-review-header.component.html
+++ b/frontend/src/app/shared/components/unit-review-header/unit-review-header.component.html
@@ -58,9 +58,9 @@
     <!-- Content Rating -->
     <div class="rating-section prevent-select">
       <p
-        pTooltip="The quality of the unit's content and resources"
+        pTooltip="How much enjoyment you get out of this unit"
         tooltipPosition="top"
-      >Content 🛈</p>
+      >Enjoyment 🛈</p>
       
       <p-knob 
         [(ngModel)]="unit.avgContentRating"
@@ -79,9 +79,9 @@
     <!-- Faculty Rating -->
     <div class="rating-section prevent-select">
       <p 
-        pTooltip="The faculty's teaching effectiveness and engagement"
+        pTooltip="How easy it is to manage the workload of this unit"
         tooltipPosition="top"
-      >Faculty 🛈</p>
+      >Simplicity 🛈</p>
       
       <p-knob 
         [(ngModel)]="unit.avgFacultyRating"
@@ -100,9 +100,9 @@
     <!-- Relevancy Rating -->
     <div class="rating-section prevent-select">
       <p
-        pTooltip="The relevance of the unit to your degree"
+        pTooltip="How useful is the content for your future career or studies"
         tooltipPosition="top"
-      >Relevancy 🛈</p>
+      >Usefulness 🛈</p>
 
       <p-knob 
         [(ngModel)]="unit.avgRelevancyRating"

--- a/frontend/src/app/shared/components/unit-review-header/unit-review-header.component.scss
+++ b/frontend/src/app/shared/components/unit-review-header/unit-review-header.component.scss
@@ -197,7 +197,7 @@
         min-width: 140px;
 
         p {
-          font-size: 1rem;
+          font-size: 1rem !important;
         }
 
         // :host ::ng-deep .p-knob {
@@ -293,6 +293,14 @@
       grid-template-columns: 1fr 1fr;
       grid-gap: 1rem;
 
+      .rating-section {
+        padding: 1rem;
+
+        p {
+          font-size: 1.1rem;
+        }
+      }
+
       /* First two rating sections: one in each column */
       .rating-section:nth-child(1) {
         grid-column: 1 / 2;
@@ -329,6 +337,12 @@
     .detailed-ratings {
       gap: 2.5rem;
       margin-right: 1rem;
+
+      .rating-section {
+        P {
+          font-size: 1.1rem;
+        }
+      }
     }
 
     // Make sure the action buttons are centered and shown in a row

--- a/frontend/src/app/shared/components/write-review-unit/write-review-unit.component.html
+++ b/frontend/src/app/shared/components/write-review-unit/write-review-unit.component.html
@@ -161,14 +161,14 @@
               ></p-dropdown>
             </div>
           }
-          <!-- * Relevancy Rating -->
-          @case ('relevancyRating') {
-            <span class="p-text-secondary block mb-4">How relevant was this unit to your degree?</span>
+          <!-- * Content Rating -->
+          @case ('contentRating') {
+            <span class="p-text-secondary block mb-4">How much did you enjoy this unit?</span>
 
             <div class="flex flex-column mb-4 centered-container">
               <app-rating
-                #relevancyRatingInput
-                [(rating)]="review.relevancyRating"
+                #contentRatingInput
+                [(rating)]="review.contentRating"
                 [stars]="5"
                 [style]="{ 'transform': 'scale(1.5)' }"
               ></app-rating>
@@ -176,7 +176,7 @@
           }
           <!-- * Faculty Rating -->
           @case ('facultyRating') {
-            <span class="p-text-secondary block mb-4">How was the teaching team? Were they supportive?</span>
+            <span class="p-text-secondary block mb-4">How manageable was the unit content?</span>
 
             <div class="flex flex-column mb-4 centered-container">
               <app-rating
@@ -187,14 +187,14 @@
               ></app-rating>
             </div>
           }
-          <!-- * Content Rating -->
-          @case ('contentRating') {
-            <span class="p-text-secondary block mb-4">What about the actual content?</span>
+          <!-- * Relevancy Rating -->
+          @case ('relevancyRating') {
+            <span class="p-text-secondary block mb-4">How useful was it for your future career or studies?</span>
 
             <div class="flex flex-column mb-4 centered-container">
               <app-rating
-                #contentRatingInput
-                [(rating)]="review.contentRating"
+                #relevancyRatingInput
+                [(rating)]="review.relevancyRating"
                 [stars]="5"
                 [style]="{ 'transform': 'scale(1.5)' }"
               ></app-rating>


### PR DESCRIPTION
Frontend Changes:
- `Content, Faculty, Relevancy` is now `Enjoyment, Simplicity, Usefulness` respectively.
- Now the rating criteria’s are easily understandable just by looking at the word and less problematic.
- This change only applies to the frontend text, I did not change the variable names or the backend names. Alot of refactoring is required. Should’ve thought about this more when we started this project 🤦‍♂️.