### PR TITLE
one review per unit & better frontend models

### DIFF
--- a/backend/routes/reviews.js
+++ b/backend/routes/reviews.js
@@ -50,20 +50,16 @@ router.get('/:unit', async function (req, res) {
     try {
         // Get the unit code from the request parameters and convert it to lowercase
         const unitCode = req.params.unit.toLowerCase();
-        //console.log(`Fetching reviews for unit: ${unitCode}`);
 
         // Find the unit in the database by its unit code
         const unitDoc = await Unit.findOne({ unitCode: unitCode });
 
         // If the unit is not found, return a 404 error
-        if (!unitDoc) {
-            console.error(`Unit with code ${unitCode} not found`);
+        if (!unitDoc)
             return res.status(404).json({ error: `Unit with code ${unitCode} not found` });
-        }
 
         // Find all reviews associated with this unit
         const reviews = await Review.find({ unit: unitDoc._id }).populate('author');
-        // console.log(`Found ${reviews.length} reviews for unit ${unitCode}`);
 
         // Return the list of reviews with a 200 OK status
         return res.status(200).json(reviews);
@@ -76,34 +72,26 @@ router.get('/:unit', async function (req, res) {
 
 
 /**
- * ! GET Get All Reviews by Author
+ * ! GET Get All Reviews by User Id
  *
- * Gets all reviews for a unit from the database.
+ * Gets all reviews by a specific user from the database.
  *
  * @async
  * @returns {JSON} Responds with a list of all reviews in JSON format.
  * @throws {500} If an error occurs whilst fetching reviews from the database.
  * @throws {404} If the unit is not found in the database.
  */
-router.get('/author/:author', async function (req, res) {
+router.get('/user/:userId', async function (req, res) {
     try {
-        // Get the author's name from the request parameters and convert it to lowercase
-        const authorName = req.params.author;
-        console.log(`Searching for ${authorName}`)
-        // const authors = await User.find({})
-        // console.log(authors)
-        const author = await User.findOne({username: authorName})
-        console.log(`Fetching reviews for author: ${author}`);
-
-        // Find all reviews associated with this unit
-        const reviews = await Review.find({ author: author._id }).populate('author').populate('unit');
-        // console.log(`Found ${reviews.length} reviews for unit ${unitCode}`);
+        // Find all reviews by this user id directly
+        const reviews = await Review.find({ author: req.params.userId })
+            .populate('unit')
+            .populate('author');
 
         // Return the list of reviews with a 200 OK status
         return res.status(200).json(reviews);
     } catch (error) {
         // Handle any errors that occur during the process
-        console.error(`An error occurred: ${error.message}`);
         return res.status(500).json({ error: `An error occurred while fetching reviews: ${error.message}` });
     }
 });
@@ -128,6 +116,16 @@ router.post('/:unit/create', verifyToken, async function (req, res) {
         // Check if unit exists, if not, return 404 error
         if (!unitDoc)
            return res.status(404).json({ error: `Unit with code ${unitCode} not found in DB` });
+
+        // Check if the user has already reviewed this unit
+        const existingReview = await Review.findOne({
+            author: req.body.review_author,
+            unit: unitDoc._id
+        });
+
+        if (existingReview) {
+            return res.status(400).json({ error: 'You have already reviewed this unit' });
+        }
 
         // The new Review object
         const review = new Review({

--- a/frontend/src/app/routes/home/home.component.ts
+++ b/frontend/src/app/routes/home/home.component.ts
@@ -188,14 +188,14 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   getPopularUnits() {
     this.loading = true;
     this.apiService.getPopularUnitsGET().subscribe({
-      next: (response: Unit[]) => {
+      next: (unitData) => {
         // Map the response data to Unit objects
-        this.popularUnits = response.map((unitData: any) => new Unit(unitData._id, unitData.unitCode, unitData.name, unitData.description, unitData.reviews, unitData.avgOverallRating, unitData.avgRelevancyRating, unitData.avgFacultyRating, unitData.avgContentRating, unitData.level, unitData.creditPoints, unitData.school, unitData.academicOrg, unitData.scaBand, unitData.requisites, unitData.offerings));
+        this.popularUnits = unitData.map(data => new Unit(data));
 
         this.loading = false;
 
         // ? Debug log success
-        console.log('Home | Popular units:', response);
+        console.log('Home | Popular units:', this.popularUnits);
       },
       error: (error) => {
         // ? Debug log error

--- a/frontend/src/app/routes/unit-list/unit-list.component.ts
+++ b/frontend/src/app/routes/unit-list/unit-list.component.ts
@@ -15,7 +15,7 @@ import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
 import { InputSwitchModule } from 'primeng/inputswitch';
 import { MultiSelectModule } from 'primeng/multiselect';
 import { FloatLabelModule } from 'primeng/floatlabel';
-import { Unit } from '../../shared/models/unit.model';
+import { Unit, UnitData } from '../../shared/models/unit.model';
 import { ScrollTopModule } from 'primeng/scrolltop';
 
 @Component({
@@ -159,7 +159,7 @@ export class UnitListComponent implements OnInit {
     this.apiService.getUnitsFilteredGET(this.first, this.rows, searchLower, this.sortBy, this.showReviewed, this.showUnreviewed, this.hideNoOfferings, this.selectedFaculty, this.selectedSemesters, this.selectedCampuses).subscribe({
       next: (response: any) => {
         // Map the response data to Unit objects
-        this.filteredUnits = response.units.map((unitData: any) => new Unit(unitData._id, unitData.unitCode, unitData.name, unitData.description, unitData.reviews, unitData.avgOverallRating, unitData.avgRelevancyRating, unitData.avgFacultyRating, unitData.avgContentRating, unitData.level, unitData.creditPoints, unitData.school, unitData.academicOrg, unitData.scaBand, unitData.requisites, unitData.offerings, unitData.tags));
+        this.filteredUnits = response.units.map((unitData: UnitData) => new Unit(unitData));
 
         // Update the total records
         this.totalRecords = response.total;

--- a/frontend/src/app/shared/components/profile/profile.component.ts
+++ b/frontend/src/app/shared/components/profile/profile.component.ts
@@ -23,6 +23,7 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { ConfirmPopupModule } from 'primeng/confirmpopup';
 import { MenubarModule } from 'primeng/menubar';
 import { ViewportService, ViewportType } from '../../services/viewport.service';
+import { Review } from '../../models/review.model';
 declare var google: any;
 
 @Component({
@@ -226,21 +227,13 @@ export class ProfileComponent implements OnInit, OnDestroy {
         // Set the current username in the update username field in details page
         this.inputUpdateUsername = this.user?.username;
 
-        // Update the profile menu label with the new username
-        const userItem = this.profileMenuItems.find(item => item.label?.startsWith('User:'));
-        if (userItem) {
-          userItem.label = `User: ${this.user?.username || 'Guest'}`;
-        }
-
         // Output to parent the updated current user
         this.userChangeEvent.emit(this.user);
 
         console.log('Fetching user reviews for:', this.user?.username);
 
         // Gets the user reviews if the user is not null
-        if (this.user?.username) {
-          this.getUserReviews(this.user.username);
-        }
+        if (this.user) this.getUserReviews(this.user._id);
         
         // console.log(this.reviews)
 
@@ -691,11 +684,11 @@ export class ProfileComponent implements OnInit, OnDestroy {
    * Called to get the user's reviews. Will call the backend API to get the user's
    * reviews and store them in the reviews array.
    * 
-   * @subscribes apiService.getUserReviewsGET(userID)
+   * @subscribes apiService.getUserReviewsGET(userId)
    */
-  getUserReviews(userID: any) {
-    this.apiService.getUserReviewsGET(userID).subscribe(
-      (reviews: any) => {
+  getUserReviews(userId: any) {
+    this.apiService.getUserReviewsGET(userId).subscribe({
+      next: (reviews: Review[]) => {
         this.reviews = reviews;
 
         // Update the reviews property in the user object
@@ -704,11 +697,11 @@ export class ProfileComponent implements OnInit, OnDestroy {
 
         console.log(this.reviews)
       },
-      (error: any) => {
+      error: (error) => {
         // ? Debug log: Error
         console.log('ERROR DURING: GET Get All Reviews', error)
       }
-    );
+    });
   }
 
   /**

--- a/frontend/src/app/shared/components/unit-review-header/unit-review-header.component.html
+++ b/frontend/src/app/shared/components/unit-review-header/unit-review-header.component.html
@@ -123,7 +123,7 @@
   <div class="actions">
     <!-- Write a Review Button -->
     <div
-      [pTooltip]="user == null ? 'You must be logged in to write a review.' : 'Write a review for this unit.'"
+      [pTooltip]="user == null ? 'You must be logged in to write a review.' : hasReviewed ? 'You have already reviewed this unit.' : 'Write a review for this unit.'"
       tooltipPosition="top"
     >
       <p-button 
@@ -133,7 +133,7 @@
         (click)="showDialog()"
         rounded="true"
         [style]="{ 'background-color': 'var(--primary-color)', 'border': 'none' }"
-        [disabled]="user == null ? true : false"
+        [disabled]="user == null ? true : hasReviewed"
       ></p-button>
     </div>
 

--- a/frontend/src/app/shared/components/write-review-unit/write-review-unit.component.ts
+++ b/frontend/src/app/shared/components/write-review-unit/write-review-unit.component.ts
@@ -413,9 +413,9 @@ export class WriteReviewUnitComponent implements OnInit {
 
     // Send the review using the API service
     this.apiService.createReviewForUnitPOST(this.unit.unitCode, this.review).subscribe({
-      next: (response) => {
+      next: (data) => {
         // Create the review object from the response
-        const review = new Review(response._id, response.title, response.semester, response.grade, response.year, response.overallRating, response.relevancyRating, response.facultyRating, response.contentRating, response.description, response.author);
+        const review = new Review(data);
 
         // Update the user's reviews array
         this.user!.reviews.push(review._id);

--- a/frontend/src/app/shared/models/review.model.ts
+++ b/frontend/src/app/shared/models/review.model.ts
@@ -1,43 +1,96 @@
+import { Unit } from "./unit.model";
 import { User } from "./user.model";
 import { Types } from "mongoose";
 
-export class Review {
-  _id: Types.ObjectId;
-  title: string;
-  semester: string;
-  grade: string;
-  year: number;
-  overallRating: number;
-  relevancyRating: number;
-  facultyRating: number;
-  contentRating: number;
-  description: string;
-  author: Types.ObjectId | null;
+// Define interface for review data
+export interface ReviewData {
+  _id?: Types.ObjectId;
+  title?: string;
+  semester?: string;
+  grade?: string;
+  year?: number;
+  overallRating?: number;
+  relevancyRating?: number;
+  facultyRating?: number;
+  contentRating?: number;
+  description?: string;
+  unit?: Types.ObjectId | Unit | null;
+  author?: Types.ObjectId | User | null;
+  likes?: number;
+  dislikes?: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
 
-  constructor (
-    _id?: Types.ObjectId,
-    title?: string,
-    semester?: string,
-    grade?: string,
-    year?: number,
-    overallRating?: number,
-    relevancyRating?: number,
-    facultyRating?: number,
-    contentRating?: number,
-    description?: string,
-    author?: Types.ObjectId | null
-  ) {
-    this._id = _id || new Types.ObjectId();
-    this.title = title || '';
-    this.semester = semester || 'First semester';
-    this.grade = grade || 'P';
-    this.year = year || new Date().getFullYear();
-    this.overallRating = overallRating ||  0;
-    this.relevancyRating = relevancyRating || 0;
-    this.facultyRating = facultyRating || 0;
-    this.contentRating = contentRating || 0;
-    this.description = description || '';
-    this.author = author || null;
+export class Review {
+  _id!: Types.ObjectId;
+  title!: string;
+  semester!: string;
+  grade!: string;
+  year!: number;
+  overallRating!: number;
+  relevancyRating!: number;
+  facultyRating!: number;
+  contentRating!: number;
+  description!: string;
+  unit!: Types.ObjectId | Unit | null;
+  author!: Types.ObjectId | User | null;
+  likes!: number;
+  dislikes!: number;
+  createdAt!: Date;
+  updatedAt!: Date;
+
+  constructor(data?: ReviewData) {
+    // Handle case where data is undefined
+    if (!data) {
+      this._id = new Types.ObjectId();
+      this.title = '';
+      this.semester = 'First semester';
+      this.grade = 'P';
+      this.year = new Date().getFullYear();
+      this.overallRating = 0;
+      this.relevancyRating = 0;
+      this.facultyRating = 0;
+      this.contentRating = 0;
+      this.description = '';
+      this.unit = null;
+      this.author = null;
+      this.likes = 0;
+      this.dislikes = 0;
+      return;
+    }
+
+    // Assign values with safe property access
+    this._id = data._id ?? new Types.ObjectId();
+    this.title = data.title ?? '';
+    this.semester = data.semester ?? 'First semester';
+    this.grade = data.grade ?? 'P';
+    this.year = data.year ?? new Date().getFullYear();
+    this.overallRating = data.overallRating ?? 0;
+    this.relevancyRating = data.relevancyRating ?? 0;
+    this.facultyRating = data.facultyRating ?? 0;
+    this.contentRating = data.contentRating ?? 0;
+    this.description = data.description ?? '';
+    this.unit = data.unit ?? null;
+    this.author = data.author ?? null;
+    this.likes = data.likes ?? 0;
+    this.dislikes = data.dislikes ?? 0;
+    this.createdAt = data.createdAt ?? new Date();
+    this.updatedAt = data.updatedAt ?? new Date();
+  }
+
+  // Utility method to check if unit is populated
+  hasPopulatedUnit(): boolean {
+    return this.unit instanceof Object && !(this.unit instanceof Types.ObjectId);
+  }
+
+  // Utility method to get unit code safely
+  getUnitCode(): string | undefined {
+    if (this.hasPopulatedUnit()) {
+      return (this.unit as Unit).unitCode;
+    }
+
+    return undefined;
   }
 
   // Validates the values
@@ -53,9 +106,9 @@ export class Review {
   }
 
   // Ensure all rating properties default to 0 if undefined
-  ensureDefaults() {
-    this.semester = this.semester ?? 1;
-    this.grade = this.grade ?? 0;
+  ensureDefaults(): void {
+    this.semester = this.semester ?? 'First semester';
+    this.grade = this.grade ?? 'P';
     this.year = this.year ?? new Date().getFullYear();
     this.overallRating = this.overallRating ?? 0;
     this.relevancyRating = this.relevancyRating ?? 0;
@@ -70,8 +123,9 @@ export class Review {
    * - Otherwise, the overall rating is the average of the provided ratings
    * - The overall rating is rounded to 1 decimal place
    */
-  calcOverallRating() {
-    const validRatings = [this.relevancyRating, this.facultyRating, this.contentRating].filter(rating => rating > 0);
+  calcOverallRating(): void {
+    const validRatings = [this.relevancyRating, this.facultyRating, this.contentRating]
+      .filter(rating => rating > 0);
     
     if (validRatings.length === 0) {
       this.overallRating = 0;

--- a/frontend/src/app/shared/models/unit.model.ts
+++ b/frontend/src/app/shared/models/unit.model.ts
@@ -7,7 +7,7 @@ export enum UnitTag {
     WAM_BOOSTER = 'wam-booster'
 }
 
-interface Requisites {
+export interface Requisites {
     permission: boolean;
     prerequisites: { NumReq: number, units: string[] }[];
     corequisites: string[];
@@ -15,7 +15,7 @@ interface Requisites {
     cpRequired: number;
 }
 
-interface Offering {
+export interface Offering {
     location: string;
     mode: string;
     name: string;
@@ -23,26 +23,128 @@ interface Offering {
     _id: Types.ObjectId;
 }
 
+// Define interface for unit data
+export interface UnitData {
+    _id?: Types.ObjectId;
+    unitCode?: string;
+    name?: string;
+    description?: string;
+    reviews?: Review[];
+    avgOverallRating?: number;
+    avgRelevancyRating?: number;
+    avgFacultyRating?: number;
+    avgContentRating?: number;
+    level?: number;
+    creditPoints?: number;
+    school?: string;
+    academicOrg?: string;
+    scaBand?: number;
+    requisites?: Requisites;
+    offerings?: Offering[];
+    tags?: UnitTag[];
+}
+
 export class Unit {
-    _id: Types.ObjectId;
-    unitCode: string;
-    name: string;
-    description: string;
-    reviews: Review[];
-    avgOverallRating: number;
-    avgRelevancyRating: number;
-    avgFacultyRating: number;
-    avgContentRating: number;
-    level: number;
-    creditPoints: number;
-    school: string;
-    academicOrg: string;
-    scaBand: number;
-    requisites: Requisites;
-    offerings: Offering[];
+    _id!: Types.ObjectId;
+    unitCode!: string;
+    name!: string;
+    description!: string;
+    reviews!: Review[];
+    avgOverallRating!: number;
+    avgRelevancyRating!: number;
+    avgFacultyRating!: number;
+    avgContentRating!: number;
+    level!: number;
+    creditPoints!: number;
+    school!: string;
+    academicOrg!: string;
+    scaBand!: number;
+    requisites!: Requisites;
+    offerings!: Offering[];
     tags: UnitTag[] = [];
 
-    constructor (
+    constructor(data?: UnitData) {
+        // Handle case where data is undefined
+        if (!data) {
+            this._id = new Types.ObjectId();
+            this.unitCode = '';
+            this.name = '';
+            this.description = '';
+            this.reviews = [];
+            this.avgOverallRating = 0;
+            this.avgRelevancyRating = 0;
+            this.avgFacultyRating = 0;
+            this.avgContentRating = 0;
+            this.level = 0;
+            this.creditPoints = 0;
+            this.school = '';
+            this.academicOrg = '';
+            this.scaBand = 0;
+            this.requisites = {
+                permission: false,
+                prerequisites: [],
+                corequisites: [],
+                prohibitions: [],
+                cpRequired: 0
+            };
+            this.offerings = [];
+            this.tags = [];
+            return;
+        }
+
+        // Assign values with safe property access
+        this._id = data._id ?? new Types.ObjectId();
+        this.unitCode = data.unitCode ?? '';
+        this.name = data.name ?? '';
+        this.description = data.description ?? '';
+        this.reviews = data.reviews ?? [];
+        this.avgOverallRating = data.avgOverallRating ?? 0;
+        this.avgRelevancyRating = data.avgRelevancyRating ?? 0;
+        this.avgFacultyRating = data.avgFacultyRating ?? 0;
+        this.avgContentRating = data.avgContentRating ?? 0;
+        this.level = data.level ?? 0;
+        this.creditPoints = data.creditPoints ?? 0;
+        this.school = data.school ?? '';
+        this.academicOrg = data.academicOrg ?? '';
+        this.scaBand = data.scaBand ?? 0;
+        this.requisites = data.requisites ?? {
+            permission: false,
+            prerequisites: [],
+            corequisites: [],
+            prohibitions: [],
+            cpRequired: 0
+        };
+        this.offerings = data.offerings ?? [];
+        this.tags = data.tags ?? [];
+    }
+
+    // Ensure all rating properties default to 0 if undefined
+    ensureDefaults(): void {
+        this.avgOverallRating = this.avgOverallRating ?? 0;
+        this.avgRelevancyRating = this.avgRelevancyRating ?? 0;
+        this.avgFacultyRating = this.avgFacultyRating ?? 0;
+        this.avgContentRating = this.avgContentRating ?? 0;
+    }
+
+    // Calculates the average ratings based on reviews
+    calculateAverageRatings(): void {
+        if (this.reviews.length > 0) {
+            this.avgOverallRating = this.reviews.reduce((sum, review) => sum + review.overallRating, 0) / this.reviews.length;
+            this.avgRelevancyRating = this.reviews.reduce((sum, review) => sum + review.relevancyRating, 0) / this.reviews.length;
+            this.avgFacultyRating = this.reviews.reduce((sum, review) => sum + review.facultyRating, 0) / this.reviews.length;
+            this.avgContentRating = this.reviews.reduce((sum, review) => sum + review.contentRating, 0) / this.reviews.length;
+        } else {
+            this.ensureDefaults();
+        }
+    }
+
+    // Helper method to check if unit has a specific tag
+    hasTag(tag: UnitTag): boolean {
+        return this.tags.includes(tag);
+    }
+
+    // Keep compatibility with old constructor form
+    static fromDetailedConstructor(
         _id: Types.ObjectId,
         unitCode: string, 
         name: string, 
@@ -60,48 +162,11 @@ export class Unit {
         requisites: Requisites,
         offerings: Offering[],
         tags?: UnitTag[]
-    ) {
-        this._id = _id;
-        this.unitCode = unitCode;
-        this.name = name;
-        this.description = description;
-        this.reviews = reviews;
-        this.avgOverallRating = avgOverallRating;
-        this.avgRelevancyRating = avgRelevancyRating;
-        this.avgFacultyRating = avgFacultyRating;
-        this.avgContentRating = avgContentRating;
-        this.level = level;
-        this.creditPoints = creditPoints;
-        this.school = school;
-        this.academicOrg = academicOrg;
-        this.scaBand = scaBand;
-        this.requisites = requisites;
-        this.offerings = offerings;
-        this.tags = tags || [];
-    }
-
-    // Ensure all rating properties default to 0 if undefined
-    ensureDefaults() {
-        this.avgOverallRating = this.avgOverallRating ?? 0;
-        this.avgRelevancyRating = this.avgRelevancyRating ?? 0;
-        this.avgFacultyRating = this.avgFacultyRating ?? 0;
-        this.avgContentRating = this.avgContentRating ?? 0;
-    }
-
-    // Calculates the average ratings based on reviews
-    calculateAverageRatings() {
-        if (this.reviews.length > 0) {
-            this.avgOverallRating = this.reviews.reduce((sum, review) => sum + review.overallRating, 0) / this.reviews.length;
-            this.avgRelevancyRating = this.reviews.reduce((sum, review) => sum + review.relevancyRating, 0) / this.reviews.length;
-            this.avgFacultyRating = this.reviews.reduce((sum, review) => sum + review.facultyRating, 0) / this.reviews.length;
-            this.avgContentRating = this.reviews.reduce((sum, review) => sum + review.contentRating, 0) / this.reviews.length;
-        } else {
-            this.ensureDefaults();
-        }
-    }
-
-    // Helper method to check if unit has a specific tag
-    hasTag(tag: UnitTag) {
-        return this.tags.includes(tag);
+    ): Unit {
+        return new Unit({
+            _id, unitCode, name, description, reviews, 
+            avgOverallRating, avgRelevancyRating, avgFacultyRating, avgContentRating,
+            level, creditPoints, school, academicOrg, scaBand, requisites, offerings, tags
+        });
     }
 }

--- a/frontend/src/app/shared/models/user.model.ts
+++ b/frontend/src/app/shared/models/user.model.ts
@@ -1,54 +1,109 @@
 import { Types } from "mongoose";
 
+// Define interface for user data
+export interface UserData {
+  _id?: Types.ObjectId;
+  email?: string;
+  username?: string;
+  isGoogleUser?: boolean;
+  reviews?: Types.ObjectId[];
+  profileImg?: string;
+  admin?: boolean;
+  verified?: boolean;
+  likedReviews?: Types.ObjectId[];
+  dislikedReviews?: Types.ObjectId[];
+}
+
 export class User {
-    _id: Types.ObjectId;
-    email: string;
-    username: string;
-    isGoogleUser: boolean;
-    reviews: Types.ObjectId[];
-    profileImg: string;
-    admin: boolean;
-    verified: boolean;
-    likedReviews: Types.ObjectId[];
-    dislikedReviews: Types.ObjectId[];
+  _id!: Types.ObjectId;
+  email!: string;
+  username!: string;
+  isGoogleUser!: boolean;
+  reviews!: Types.ObjectId[];
+  profileImg!: string;
+  admin!: boolean;
+  verified!: boolean;
+  likedReviews!: Types.ObjectId[];
+  dislikedReviews!: Types.ObjectId[];
 
-    constructor (
-        _id?: Types.ObjectId, 
-        email?: string, 
-        username?: string, 
-        isGoogleUser?: boolean,
-        reviews?: Types.ObjectId[], 
-        profileImg?: string, 
-        admin?: boolean, 
-        verified?: boolean, 
-        likedReviews?: Types.ObjectId[],
-        dislikedReviews?: Types.ObjectId[]
-    ) {
-        this._id = _id || new Types.ObjectId();
-        this.email = email || '';
-        this.username = username || email?.slice(0, 8) || '';
-        this.isGoogleUser = isGoogleUser || false;
-        this.reviews = reviews || [];
-        this.profileImg = profileImg || 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSWwfGUCDwrZZK12xVpCOqngxSpn0BDpq6ewQ&s';
-        this.admin = admin || false;
-        this.verified = verified || false;
-        this.likedReviews = likedReviews || [];
-        this.dislikedReviews = dislikedReviews || [];
+  constructor(data?: UserData) {
+    // Default avatar URL
+    const defaultAvatar = 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSWwfGUCDwrZZK12xVpCOqngxSpn0BDpq6ewQ&s';
+    
+    if (!data) {
+      // Handle case where data is undefined
+      this._id = new Types.ObjectId();
+      this.email = '';
+      this.username = '';
+      this.isGoogleUser = false;
+      this.reviews = [];
+      this.profileImg = defaultAvatar;
+      this.admin = false;
+      this.verified = false;
+      this.likedReviews = [];
+      this.dislikedReviews = [];
+      return;
     }
 
-    addLikedReview(reviewId: Types.ObjectId): void {
-        this.likedReviews.push(reviewId);
-    }
+    // Assign values with safe property access
+    this._id = data._id ?? new Types.ObjectId();
+    this.email = data.email ?? '';
+    
+    // Derive username from email if not provided
+    this.username = data.username ?? (data.email?.slice(0, 8) ?? '');
+    
+    this.isGoogleUser = data.isGoogleUser ?? false;
+    this.reviews = data.reviews ?? [];
+    this.profileImg = data.profileImg ?? defaultAvatar;
+    this.admin = data.admin ?? false;
+    this.verified = data.verified ?? false;
+    this.likedReviews = data.likedReviews ?? [];
+    this.dislikedReviews = data.dislikedReviews ?? [];
+  }
 
-    removeLikedReview(reviewId: Types.ObjectId): void {
-        this.likedReviews = this.likedReviews.filter(id => id !== reviewId);
-    }
+  // Maintain backward compaitibility for constructing User objects
+  static fromDetailedConstructor(
+    _id?: Types.ObjectId, 
+    email?: string, 
+    username?: string, 
+    isGoogleUser?: boolean,
+    reviews?: Types.ObjectId[], 
+    profileImg?: string, 
+    admin?: boolean, 
+    verified?: boolean, 
+    likedReviews?: Types.ObjectId[],
+    dislikedReviews?: Types.ObjectId[]
+  ): User {
+    return new User({
+      _id, email, username, isGoogleUser, reviews,
+      profileImg, admin, verified, likedReviews, dislikedReviews
+    });
+  }
 
-    addDislikedReview(reviewId: Types.ObjectId): void {
-        this.dislikedReviews.push(reviewId);
-    }
+  addLikedReview(reviewId: Types.ObjectId): void {
+    this.likedReviews.push(reviewId);
+  }
 
-    removeDislikedReview(reviewId: Types.ObjectId): void {
-        this.dislikedReviews = this.dislikedReviews.filter(id => id !== reviewId);
-    }
+  removeLikedReview(reviewId: Types.ObjectId): void {
+    this.likedReviews = this.likedReviews.filter(id => id !== reviewId);
+  }
+
+  addDislikedReview(reviewId: Types.ObjectId): void {
+    this.dislikedReviews.push(reviewId);
+  }
+
+  removeDislikedReview(reviewId: Types.ObjectId): void {
+    this.dislikedReviews = this.dislikedReviews.filter(id => id !== reviewId);
+  }
+
+  // Additional helper methods
+  hasLikedReview(reviewId: Types.ObjectId | string): boolean {
+    const idString = reviewId.toString();
+    return this.likedReviews.some(id => id.toString() === idString);
+  }
+
+  hasDislikedReview(reviewId: Types.ObjectId | string): boolean {
+    const idString = reviewId.toString();
+    return this.dislikedReviews.some(id => id.toString() === idString);
+  }
 }

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -4,7 +4,7 @@ import { Review } from '../models/review.model';
 import { Observable, tap } from 'rxjs';
 import { AuthService } from './auth.service';
 import { User } from '../models/user.model';
-import { Types } from 'mongoose';
+import { ObjectId, Types } from 'mongoose';
 import { Unit } from '../models/unit.model';
 
 interface ReportPayload {
@@ -56,10 +56,25 @@ export class ApiService {
 
   /**
    * * GET Gets the reviews written by a user
+   * 
+   * Retrieves all reviews written by a specific user.
+   * 
+   * @param {string} userId The ID of the user
+   * @returns {Observable<any>} An observable containing the reviews data
    */
-  getUserReviewsGET(userID: string): Observable<any> {
-    const url = `${this.url}/reviews/author/${userID}`;
-    return this.http.get(url);
+  getUserReviewsGET(userId: string): Observable<any> {
+    return this.http.get(
+      `${this.url}/reviews/user/${userId}`
+    ).pipe(
+      tap({
+        next: (response) => {
+          console.log('ApiService | Successfully fetched user reviews:', response);
+        },
+        error: (error) => {
+          console.log('ApiService | Error whilst fetching user reviews:', error.error);
+        }
+      })
+    );
   }
 
   /**

--- a/frontend/src/app/shared/services/auth.service.ts
+++ b/frontend/src/app/shared/services/auth.service.ts
@@ -9,7 +9,7 @@ import { ObjectId } from 'mongoose';
 })
 export class AuthService {
   // URL for backend endpoints
-  private url = 'http://localhost:8080/api/v1';
+  private url = 'http://localhost:8080/api/v1/auth';
 
   // Stores the current user as behaviour subject of type User (nullable)
   private currentUser = new BehaviorSubject<User | null>(null);
@@ -58,18 +58,7 @@ export class AuthService {
     ).pipe(
       tap((response: any) => {
         // Update the current user with the response data
-        const user = new User(
-          response.data._id, 
-          response.data.email, 
-          response.data.username, 
-          response.data.isGoogleUser,
-          response.data.reviews, 
-          response.data.profileImg, 
-          response.data.admin, 
-          response.data.verified,
-          response.data.likedReviews,
-          response.data.dislikedReviews 
-        );
+        const user = new User(response.data);
         this.currentUser.next(user);
 
         // ? Debug log
@@ -95,18 +84,7 @@ export class AuthService {
     ).pipe(
       tap((response: any) => {
         // Update the current user with the response data
-        const user = new User(
-          response.data._id, 
-          response.data.email, 
-          response.data.username,
-          response.data.isGoogleUser, 
-          response.data.reviews, 
-          response.data.profileImg, 
-          response.data.admin, 
-          response.data.verified,
-          response.data.likedReviews,
-          response.data.dislikedReviews 
-        );
+        const user = new User(response.data);
         this.currentUser.next(user);
 
         // ? Debug log
@@ -173,18 +151,7 @@ export class AuthService {
     ).pipe(
       tap((response: any) => {
         // Update the current user with the response data
-        const user = new User(
-          response.data._id, 
-          response.data.email, 
-          response.data.username, 
-          response.data.isGoogleUser,
-          response.data.reviews, 
-          response.data.profileImg, 
-          response.data.admin, 
-          response.data.verified,
-          response.data.likedReviews,
-          response.data.dislikedReviews 
-        );
+        const user = new User(response.data);
         this.currentUser.next(user);
 
         // ? Debug log
@@ -208,18 +175,7 @@ export class AuthService {
     ).pipe(
       tap((response: any) => {
         // Update the current user with the response data
-        const user = new User(
-          response.data._id, 
-          response.data.email, 
-          response.data.username, 
-          response.data.isGoogleUser,
-          response.data.reviews, 
-          response.data.profileImg, 
-          response.data.admin, 
-          response.data.verified,
-          response.data.likedReviews,
-          response.data.dislikedReviews 
-        );
+        const user = new User(response.data);
         this.currentUser.next(user);
 
         // ? Debug log


### PR DESCRIPTION
FRONTEND CHANGES
- Checking if a user has already review a unit in `unit-review-header`, there is a new boolean variable `hasReviewed` which is set to true if the user has already reviewed the unit. `checkHasReviewed` is called on initialisation and checks all of the user’s reviews to see if any of them are for the current unit, this is done using the API service method `getUserReviewsGET`.
- The “Write Review” button will be disabled if `hasReviewed` is true.
- Upgraded the frontend `user`, `review`, and `unit` models to have better practice class structure and constructors.

BACKEND CHANGES
- Had to change the backend API endpoint for api/v1/reviews/author/:author to api/v1/reviews/:userId. It’s better to use the mongodb id instead of the username to find the user.