### PR TITLE
bugfix: unit-overview scroll improvements

### DIFF
--- a/frontend/src/app/routes/unit-overview/unit-overview.component.html
+++ b/frontend/src/app/routes/unit-overview/unit-overview.component.html
@@ -7,17 +7,22 @@
     class="unit-overview-container" 
 >
     <div class="left-column">
-        <!-- ! CHILD: UnitHeaderComponent -->
-        <!-- Unit review header -->
-        <app-unit-review-header 
-            [unit]="unit"
-            (sortBy)="sortReviews($event)"
-            (reviewAdded)="refreshReviews()"
-        />
+        <p-scrollPanel
+            styleClass="left-column-scroll"
+            [style]="{ 'width': '100%', 'height': '100%' }"
+        >
+            <!-- ! CHILD: UnitHeaderComponent -->
+            <!-- Unit review header -->
+            <app-unit-review-header 
+                [unit]="unit"
+                (sortBy)="sortReviews($event)"
+                (reviewAdded)="refreshReviews()"
+            />
 
-        <!-- ! CHILD: SetuCardComponent -->
-        <!-- Setu header -->
-        <app-setu-card [unitCode]="unit?.unitCode"/>
+            <!-- ! CHILD: SetuCardComponent -->
+            <!-- Setu header -->
+            <app-setu-card [unitCode]="unit?.unitCode"/>
+        </p-scrollPanel>
     </div>
     <div class="right-column">
         <p-scrollPanel 

--- a/frontend/src/app/routes/unit-overview/unit-overview.component.scss
+++ b/frontend/src/app/routes/unit-overview/unit-overview.component.scss
@@ -33,6 +33,14 @@
             overflow: hidden;
             padding-right: 1.5rem;
 
+            .left-column-scroll {
+                width: 100%;
+                height: 100%;
+                .p-scrollpanel-content {
+                    padding: 1rem;
+                }
+            }
+
             // Update unit review header styles
             ::ng-deep app-unit-review-header .unit-review-header {
                 padding: 0.75rem;

--- a/frontend/src/app/routes/unit-overview/unit-overview.component.ts
+++ b/frontend/src/app/routes/unit-overview/unit-overview.component.ts
@@ -286,17 +286,9 @@ export class UnitOverviewComponent implements OnInit, AfterViewInit, OnDestroy {
     // No change if we're in split view
     if (this.isSplitView) {
       this.unitOverviewContainer.nativeElement.style.height = '';
-      return
-    }
-
-    if (this.reviews.length > 1) {
-      // 2 or more reviews, grow to full height.
+    } else {
       this.unitOverviewContainer.nativeElement.style.height = '100%';
-    }
-    else if (this.reviews.length <= 1) {
-      // Prevent scrolling and calculate height based on navbar height
-      this.unitOverviewContainer.nativeElement.style.height = `calc(100vh - ${NAVBAR_HEIGHT})`;
-      this.unitOverviewContainer.nativeElement.style.overflow = 'hidden';
+      this.unitOverviewContainer.nativeElement.style.overflow = '';
     }
   }
 


### PR DESCRIPTION
- Fixed a bug where you couldn't scroll when there was one review in the vertical format.

- Made the left column of the unit-overview scrollable, to allow users to see the setu header when there is hidden vertical overflow.