### PR TITLE
Org images for jobs + admins can edit

### DIFF
--- a/backend/infra/controllers/orgLogo.controller.js
+++ b/backend/infra/controllers/orgLogo.controller.js
@@ -1,0 +1,40 @@
+const asyncHandler = require('express-async-handler');
+
+const OrgLogoService = require('@services/orgLogo.service');
+
+class OrgLogoController {
+  static getAll = asyncHandler(async (req, res) => {
+    const logos = await OrgLogoService.getAll();
+    return res.status(200).json(logos);
+  });
+
+  static upload = asyncHandler(async (req, res) => {
+    const { organisation } = req.body;
+    if (!organisation) {
+      return res.status(400).json({ error: 'Organisation name is required' });
+    }
+
+    if (!req.file) {
+      return res.status(400).json({ error: 'Logo file is required' });
+    }
+
+    const logoUrl = req.file.path;
+    const logo = await OrgLogoService.uploadLogo(organisation, logoUrl);
+    return res
+      .status(200)
+      .json({ message: 'Logo uploaded successfully', data: logo });
+  });
+
+  static delete = asyncHandler(async (req, res) => {
+    const organisation = decodeURIComponent(req.params.organisation);
+    const deleted = await OrgLogoService.deleteLogo(organisation);
+
+    if (!deleted) {
+      return res.status(404).json({ error: 'Logo not found' });
+    }
+
+    return res.status(200).json({ message: 'Logo deleted successfully' });
+  });
+}
+
+module.exports = OrgLogoController;

--- a/backend/infra/controllers/orgLogo.controller.js
+++ b/backend/infra/controllers/orgLogo.controller.js
@@ -26,7 +26,7 @@ class OrgLogoController {
   });
 
   static delete = asyncHandler(async (req, res) => {
-    const organisation = decodeURIComponent(req.params.organisation);
+    const organisation = req.params.organisation;
     const deleted = await OrgLogoService.deleteLogo(organisation);
 
     if (!deleted) {

--- a/backend/infra/controllers/review.controller.js
+++ b/backend/infra/controllers/review.controller.js
@@ -18,7 +18,7 @@ class ReviewController {
   static getMostLiked = asyncHandler(async (req, res) => {
     const reviews = await ReviewService.fetchMostLiked(req.query.n);
     return res.status(200).json(reviews);
-  })
+  });
 
   /**
    * Get all reviews for a specific unit

--- a/backend/infra/middleware/admin.middleware.js
+++ b/backend/infra/middleware/admin.middleware.js
@@ -2,12 +2,14 @@ const { CreateError } = require('@utilities/error');
 
 const userMiddleware = require('./user.middleware');
 
-const adminMiddleware = (err, req, res, next) => {
-  userMiddleware(req, res, () => {
-    if (req.user.admin) next();
+const adminMiddleware = (req, res, next) => {
+  userMiddleware(req, res, (err) => {
+    if (err) return next(err);
+
+    if (req.user?.isAdmin) return next();
 
     return next(
-      CreateError(403, 'You are not authorized! You are not an admin.')
+      CreateError(403, 'You are not authorised! You are not an admin.')
     );
   });
 };

--- a/backend/infra/providers/cloudinary.provider.js
+++ b/backend/infra/providers/cloudinary.provider.js
@@ -28,5 +28,24 @@ const storage = new CloudinaryStorage({
   },
 });
 
-// Export the Cloudinary instance and storage engine
-module.exports = { cloudinary, storage };
+// Create a Cloudinary storage instance for organisation logos
+const orgStorage = new CloudinaryStorage({
+  cloudinary,
+  params: {
+    folder: 'orgs',
+    allowed_formats: ['jpg', 'png', 'jpeg', 'svg', 'webp'],
+    transformation: [
+      {
+        width: 200,
+        height: 200,
+        crop: 'fill',
+        gravity: 'auto',
+        fetch_format: 'auto',
+        quality: 'auto',
+      },
+    ],
+  },
+});
+
+// Export the Cloudinary instance and storage engines
+module.exports = { cloudinary, storage, orgStorage };

--- a/backend/infra/repositories/orgLogo.repository.js
+++ b/backend/infra/repositories/orgLogo.repository.js
@@ -1,0 +1,30 @@
+const OrgLogo = require('@models/orgLogo');
+
+class OrgLogoRepository {
+  static async findAll() {
+    return await OrgLogo.find();
+  }
+
+  static async findByOrganisation(org) {
+    return await OrgLogo.findOne({
+      organisation: org.toLowerCase().trim(),
+    });
+  }
+
+  static async upsert(org, logoUrl) {
+    const normalised = org.toLowerCase().trim();
+    return await OrgLogo.findOneAndUpdate(
+      { organisation: normalised },
+      { organisation: normalised, logoUrl },
+      { upsert: true, new: true }
+    );
+  }
+
+  static async deleteByOrganisation(org) {
+    return await OrgLogo.findOneAndDelete({
+      organisation: org.toLowerCase().trim(),
+    });
+  }
+}
+
+module.exports = OrgLogoRepository;

--- a/backend/infra/routes/v2/jobs.js
+++ b/backend/infra/routes/v2/jobs.js
@@ -1,9 +1,14 @@
 const express = require('express');
+const multer = require('multer');
 
 const JobController = require('@controllers/job.controller');
+const OrgLogoController = require('@controllers/orgLogo.controller');
+const adminMiddleware = require('@middleware/admin.middleware');
 const userMiddleware = require('@middleware/user.middleware');
+const { orgStorage } = require('@providers/cloudinary.provider');
 
 const router = express.Router();
+const uploadLogo = multer({ storage: orgStorage });
 
 router.get(
   '/',
@@ -17,6 +22,30 @@ router.get(
   // #swagger.tags = ['Jobs']
   // #swagger.summary = 'Get all open job listings'
   JobController.getOpen
+);
+
+router.get(
+  '/logos',
+  // #swagger.tags = ['Jobs']
+  // #swagger.summary = 'Get all organisation logos'
+  OrgLogoController.getAll
+);
+
+router.put(
+  '/logos',
+  adminMiddleware,
+  uploadLogo.single('logo'),
+  // #swagger.tags = ['Jobs']
+  // #swagger.summary = 'Upload or update an organisation logo (admin only)'
+  OrgLogoController.upload
+);
+
+router.delete(
+  '/logos/:organisation',
+  adminMiddleware,
+  // #swagger.tags = ['Jobs']
+  // #swagger.summary = 'Delete an organisation logo (admin only)'
+  OrgLogoController.delete
 );
 
 router.get(

--- a/backend/infra/services/orgLogo.service.js
+++ b/backend/infra/services/orgLogo.service.js
@@ -1,0 +1,55 @@
+const { cloudinary } = require('@providers/cloudinary.provider');
+const OrgLogoRepository = require('@repositories/orgLogo.repository');
+
+class OrgLogoService {
+  static normalise(name) {
+    return name.toLowerCase().trim();
+  }
+
+  static async getAll() {
+    return await OrgLogoRepository.findAll();
+  }
+
+  static async uploadLogo(orgName, logoUrl) {
+    const normalised = this.normalise(orgName);
+
+    // Delete old Cloudinary image if one already exists
+    const existing = await OrgLogoRepository.findByOrganisation(normalised);
+    if (existing) {
+      try {
+        const urlParts = existing.logoUrl.split('/');
+        const fileName = urlParts[urlParts.length - 1].split('.')[0];
+        const publicId = `orgs/${fileName}`;
+        await cloudinary.uploader.destroy(publicId);
+      } catch (err) {
+        console.error(
+          `[OrgLogo] Error deleting old image from Cloudinary: ${err.message}`
+        );
+      }
+    }
+
+    return await OrgLogoRepository.upsert(normalised, logoUrl);
+  }
+
+  static async deleteLogo(orgName) {
+    const normalised = this.normalise(orgName);
+    const logo = await OrgLogoRepository.findByOrganisation(normalised);
+    if (!logo) return null;
+
+    // Delete from Cloudinary
+    try {
+      const urlParts = logo.logoUrl.split('/');
+      const fileName = urlParts[urlParts.length - 1].split('.')[0];
+      const publicId = `orgs/${fileName}`;
+      await cloudinary.uploader.destroy(publicId);
+    } catch (err) {
+      console.error(
+        `[OrgLogo] Error deleting image from Cloudinary: ${err.message}`
+      );
+    }
+
+    return await OrgLogoRepository.deleteByOrganisation(normalised);
+  }
+}
+
+module.exports = OrgLogoService;

--- a/backend/models/orgLogo.js
+++ b/backend/models/orgLogo.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const orgLogoSchema = new Schema(
+  {
+    organisation: { type: String, required: true, unique: true },
+    logoUrl: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+// Normalise org name to lowercase + trimmed before saving
+orgLogoSchema.pre('save', function (next) {
+  if (this.organisation) {
+    this.organisation = this.organisation.toLowerCase().trim();
+  }
+  next();
+});
+
+const OrgLogo = mongoose.model('OrgLogo', orgLogoSchema);
+module.exports = OrgLogo;

--- a/frontend/src/app/routes/jobs-board/jobs-board.component.html
+++ b/frontend/src/app/routes/jobs-board/jobs-board.component.html
@@ -12,7 +12,16 @@
     <div class="p-toolbar-group-start">
       <div>
         <h2 class="jobs-title">Monash University Student Roles</h2>
-        <span class="jobs-attribution">Special thanks to <a href="https://www.instagram.com/openuniroles" target="_blank" rel="noopener noreferrer">&commat;openuniroles</a> for providing the data.</span>
+        <span class="jobs-attribution"
+          >Special thanks to
+          <a
+            href="https://www.instagram.com/openuniroles"
+            target="_blank"
+            rel="noopener noreferrer"
+            >&commat;openuniroles</a
+          >
+          for providing the data.</span
+        >
       </div>
     </div>
     <div class="p-toolbar-group-end filters">
@@ -38,67 +47,87 @@
   <div class="jobs-content">
     <!-- Left Panel: Job List -->
     @if (!mobileDetailOpen) {
-    <div class="left-panel">
-      <p-scrollPanel
-        styleClass="job-list-scroll"
-        [style]="{ width: '100%', height: '100%' }"
-      >
-        @if (loading) {
-          @for (i of [1, 2, 3, 4, 5]; track $index) {
-            <div class="job-card skeleton-card">
-              <p-skeleton width="70%" height="1.2rem" borderRadius="8px"></p-skeleton>
-              <p-skeleton width="50%" height="1rem" borderRadius="8px" styleClass="mt-2"></p-skeleton>
-              <div class="skeleton-chips mt-2">
-                <p-skeleton width="60px" height="1.5rem" borderRadius="12px"></p-skeleton>
-                <p-skeleton width="80px" height="1.5rem" borderRadius="12px"></p-skeleton>
-              </div>
-            </div>
-          }
-        } @else if (filteredJobs.length === 0) {
-          <div class="empty-state">
-            <i class="pi pi-briefcase"></i>
-            <p>No jobs match your filters.</p>
-          </div>
-        } @else {
-          @for (job of filteredJobs; track job.notionId) {
-            <div
-              class="job-card"
-              [class.active]="selectedJob === job"
-              (click)="selectJob(job)"
-            >
-              <div
-                class="job-card-icon"
-                [class.admin-clickable]="isAdmin && !getLogoUrl(job)"
-                (click)="$event.stopPropagation(); isAdmin && !getLogoUrl(job) && onLogoUpload(job)"
-              >
-                @if (getLogoUrl(job)) {
-                  <img [src]="getLogoUrl(job)" [alt]="job.organisation + ' logo'" />
-                } @else if (isAdmin) {
-                  <i class="pi pi-building"></i>
-                  <span class="upload-hint">+</span>
-                } @else {
-                  <i class="pi pi-building"></i>
-                }
-              </div>
-              <div class="job-card-body">
-                <div class="job-card-header">
-                  <span class="job-card-title">{{ job.organisation }}</span>
-                  <p-tag
-                    [value]="job.status"
-                    [severity]="getStatusSeverity(job.status)"
-                  ></p-tag>
+      <div class="left-panel">
+        <p-scrollPanel
+          styleClass="job-list-scroll"
+          [style]="{ width: '100%', height: '100%' }"
+        >
+          @if (loading) {
+            @for (i of [1, 2, 3, 4, 5]; track $index) {
+              <div class="job-card skeleton-card">
+                <p-skeleton
+                  width="70%"
+                  height="1.2rem"
+                  borderRadius="8px"
+                ></p-skeleton>
+                <p-skeleton
+                  width="50%"
+                  height="1rem"
+                  borderRadius="8px"
+                  styleClass="mt-2"
+                ></p-skeleton>
+                <div class="skeleton-chips mt-2">
+                  <p-skeleton
+                    width="60px"
+                    height="1.5rem"
+                    borderRadius="12px"
+                  ></p-skeleton>
+                  <p-skeleton
+                    width="80px"
+                    height="1.5rem"
+                    borderRadius="12px"
+                  ></p-skeleton>
                 </div>
-                <div class="job-card-chips">
-                  @for (role of job.roleType; track role) {
-                    <p-chip [label]="role" styleClass="role-chip"></p-chip>
+              </div>
+            }
+          } @else if (filteredJobs.length === 0) {
+            <div class="empty-state">
+              <i class="pi pi-briefcase"></i>
+              <p>No jobs match your filters.</p>
+            </div>
+          } @else {
+            @for (job of filteredJobs; track job.notionId) {
+              <div
+                class="job-card"
+                [class.active]="selectedJob === job"
+                (click)="selectJob(job)"
+              >
+                <div
+                  class="job-card-icon"
+                  [class.admin-clickable]="isAdmin && !getLogoUrl(job)"
+                  (click)="onIconClick($event, job)"
+                >
+                  @if (getLogoUrl(job)) {
+                    <img
+                      [src]="getLogoUrl(job)"
+                      [alt]="job.organisation + ' logo'"
+                    />
+                  } @else if (isAdmin) {
+                    <i class="pi pi-building"></i>
+                    <span class="upload-hint">+</span>
+                  } @else {
+                    <i class="pi pi-building"></i>
                   }
                 </div>
+                <div class="job-card-body">
+                  <div class="job-card-header">
+                    <span class="job-card-title">{{ job.organisation }}</span>
+                    <p-tag
+                      [value]="job.status"
+                      [severity]="getStatusSeverity(job.status)"
+                    ></p-tag>
+                  </div>
+                  <div class="job-card-chips">
+                    @for (role of job.roleType; track role) {
+                      <p-chip [label]="role" styleClass="role-chip"></p-chip>
+                    }
+                  </div>
+                </div>
               </div>
-            </div>
+            }
           }
-        }
-      </p-scrollPanel>
-    </div>
+        </p-scrollPanel>
+      </div>
     }
 
     <!-- Right Panel: Job Detail (desktop side-by-side) -->
@@ -109,12 +138,41 @@
       >
         @if (loading) {
           <div class="job-detail">
-            <p-skeleton width="80%" height="2rem" borderRadius="8px"></p-skeleton>
-            <p-skeleton width="50%" height="1.2rem" borderRadius="8px" styleClass="mt-3"></p-skeleton>
-            <p-skeleton width="100%" height="1rem" borderRadius="8px" styleClass="mt-4"></p-skeleton>
-            <p-skeleton width="100%" height="1rem" borderRadius="8px" styleClass="mt-2"></p-skeleton>
-            <p-skeleton width="100%" height="1rem" borderRadius="8px" styleClass="mt-2"></p-skeleton>
-            <p-skeleton width="60%" height="1rem" borderRadius="8px" styleClass="mt-2"></p-skeleton>
+            <p-skeleton
+              width="80%"
+              height="2rem"
+              borderRadius="8px"
+            ></p-skeleton>
+            <p-skeleton
+              width="50%"
+              height="1.2rem"
+              borderRadius="8px"
+              styleClass="mt-3"
+            ></p-skeleton>
+            <p-skeleton
+              width="100%"
+              height="1rem"
+              borderRadius="8px"
+              styleClass="mt-4"
+            ></p-skeleton>
+            <p-skeleton
+              width="100%"
+              height="1rem"
+              borderRadius="8px"
+              styleClass="mt-2"
+            ></p-skeleton>
+            <p-skeleton
+              width="100%"
+              height="1rem"
+              borderRadius="8px"
+              styleClass="mt-2"
+            ></p-skeleton>
+            <p-skeleton
+              width="60%"
+              height="1rem"
+              borderRadius="8px"
+              styleClass="mt-2"
+            ></p-skeleton>
           </div>
         } @else if (!selectedJob) {
           <div class="empty-state">
@@ -130,7 +188,11 @@
 
   <!-- Mobile Full-Screen Detail Overlay -->
   @if (mobileDetailOpen && selectedJob) {
-    <div class="mobile-detail-overlay" (wheel)="$event.stopPropagation()" (touchmove)="$event.stopPropagation()">
+    <div
+      class="mobile-detail-overlay"
+      (wheel)="$event.stopPropagation()"
+      (touchmove)="$event.stopPropagation()"
+    >
       <button class="mobile-close-btn" (click)="closeDetail()">
         <i class="pi pi-times"></i>
       </button>
@@ -158,21 +220,31 @@
     <div class="detail-fields">
       @if (selectedJob!.timeCommitment.length > 0) {
         <div class="detail-field">
-          <span class="field-label"><i class="pi pi-clock"></i> Time Commitment</span>
-          <span class="field-value">{{ selectedJob!.timeCommitment.join(', ') }}</span>
+          <span class="field-label"
+            ><i class="pi pi-clock"></i> Time Commitment</span
+          >
+          <span class="field-value">{{
+            selectedJob!.timeCommitment.join(', ')
+          }}</span>
         </div>
       }
 
       @if (selectedJob!.closeDate) {
         <div class="detail-field">
-          <span class="field-label"><i class="pi pi-calendar"></i> Close Date</span>
-          <span class="field-value">{{ formatDate(selectedJob!.closeDate) }}</span>
+          <span class="field-label"
+            ><i class="pi pi-calendar"></i> Close Date</span
+          >
+          <span class="field-value">{{
+            formatDate(selectedJob!.closeDate)
+          }}</span>
         </div>
       }
 
       @if (selectedJob!.eligibility) {
         <div class="detail-field">
-          <span class="field-label"><i class="pi pi-users"></i> Eligibility</span>
+          <span class="field-label"
+            ><i class="pi pi-users"></i> Eligibility</span
+          >
           <span class="field-value">{{ selectedJob!.eligibility }}</span>
         </div>
       }
@@ -186,15 +258,21 @@
 
       @if (selectedJob!.interviewWindow) {
         <div class="detail-field">
-          <span class="field-label"><i class="pi pi-comments"></i> Interview Window</span>
+          <span class="field-label"
+            ><i class="pi pi-comments"></i> Interview Window</span
+          >
           <span class="field-value">{{ selectedJob!.interviewWindow }}</span>
         </div>
       }
 
       @if (selectedJob!.lastVerified) {
         <div class="detail-field">
-          <span class="field-label"><i class="pi pi-check-circle"></i> Last Verified</span>
-          <span class="field-value">{{ formatDate(selectedJob!.lastVerified) }}</span>
+          <span class="field-label"
+            ><i class="pi pi-check-circle"></i> Last Verified</span
+          >
+          <span class="field-value">{{
+            formatDate(selectedJob!.lastVerified)
+          }}</span>
         </div>
       }
     </div>

--- a/frontend/src/app/routes/jobs-board/jobs-board.component.html
+++ b/frontend/src/app/routes/jobs-board/jobs-board.component.html
@@ -1,3 +1,11 @@
+<input
+  #logoFileInput
+  type="file"
+  accept="image/*"
+  style="display: none"
+  (change)="onFileSelected($event)"
+/>
+
 <div #jobsBoardContainer class="jobs-board-container">
   <!-- Toolbar -->
   <p-toolbar styleClass="jobs-toolbar">
@@ -58,8 +66,19 @@
               [class.active]="selectedJob === job"
               (click)="selectJob(job)"
             >
-              <div class="job-card-icon">
-                <i class="pi pi-building"></i>
+              <div
+                class="job-card-icon"
+                [class.admin-clickable]="isAdmin && !getLogoUrl(job)"
+                (click)="$event.stopPropagation(); isAdmin && !getLogoUrl(job) && onLogoUpload(job)"
+              >
+                @if (getLogoUrl(job)) {
+                  <img [src]="getLogoUrl(job)" [alt]="job.organisation + ' logo'" />
+                } @else if (isAdmin) {
+                  <i class="pi pi-building"></i>
+                  <span class="upload-hint">+</span>
+                } @else {
+                  <i class="pi pi-building"></i>
+                }
               </div>
               <div class="job-card-body">
                 <div class="job-card-header">

--- a/frontend/src/app/routes/jobs-board/jobs-board.component.html
+++ b/frontend/src/app/routes/jobs-board/jobs-board.component.html
@@ -94,7 +94,7 @@
               >
                 <div
                   class="job-card-icon"
-                  [class.admin-clickable]="isAdmin && !getLogoUrl(job)"
+                  [class.admin-clickable]="isAdmin"
                   (click)="onIconClick($event, job)"
                 >
                   @if (getLogoUrl(job)) {

--- a/frontend/src/app/routes/jobs-board/jobs-board.component.scss
+++ b/frontend/src/app/routes/jobs-board/jobs-board.component.scss
@@ -120,6 +120,7 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  position: relative;
 
   i {
     color: rgba(255, 255, 255, 0.4);
@@ -131,6 +132,38 @@
     height: 100%;
     object-fit: cover;
     border-radius: 8px;
+  }
+
+  .upload-hint {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    background-color: $primary-color;
+    color: white;
+    font-size: 0.65rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  &.admin-clickable {
+    cursor: pointer;
+    transition: outline-color 0.2s ease;
+
+    &:hover {
+      outline: 1px dashed rgba(255, 255, 255, 0.3);
+      outline-offset: 2px;
+
+      .upload-hint {
+        opacity: 1;
+      }
+    }
   }
 }
 

--- a/frontend/src/app/routes/jobs-board/jobs-board.component.ts
+++ b/frontend/src/app/routes/jobs-board/jobs-board.component.ts
@@ -193,6 +193,13 @@ export class JobsBoardComponent implements OnInit, OnDestroy {
     return this.orgLogoMap.get(job.organisation.toLowerCase().trim());
   }
 
+  onIconClick(event: MouseEvent, job: IJob): void {
+    if (this.isAdmin && !this.getLogoUrl(job)) {
+      event.stopPropagation();
+      this.onLogoUpload(job);
+    }
+  }
+
   onLogoUpload(job: IJob): void {
     this._uploadTargetOrg = job.organisation;
     this.logoFileInput.nativeElement.click();

--- a/frontend/src/app/routes/jobs-board/jobs-board.component.ts
+++ b/frontend/src/app/routes/jobs-board/jobs-board.component.ts
@@ -12,7 +12,10 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { Meta, Title } from '@angular/platform-browser';
 import { JobService } from '@services/api/jobs.api.service';
+import { UserService } from '@services/api/user.service';
 import { IJob } from '@models/job.schema';
+import { buildOrgLogoMap } from '../../shared/utils/string-similarity';
+import { forkJoin } from 'rxjs';
 import { ButtonModule } from 'primeng/button';
 import { DropdownModule } from 'primeng/dropdown';
 import { ScrollPanelModule } from 'primeng/scrollpanel';
@@ -41,9 +44,11 @@ import { FooterService } from '../../shared/services/footer.service';
 })
 export class JobsBoardComponent implements OnInit, OnDestroy {
   @ViewChild('jobsBoardContainer') jobsBoardContainer!: ElementRef;
+  @ViewChild('logoFileInput') logoFileInput!: ElementRef<HTMLInputElement>;
 
   private destroyRef = inject(DestroyRef);
   private jobService = inject(JobService);
+  private userService = inject(UserService);
   private meta = inject(Meta);
   private titleService = inject(Title);
   private footerService = inject(FooterService);
@@ -53,6 +58,10 @@ export class JobsBoardComponent implements OnInit, OnDestroy {
   selectedJob: IJob | null = null;
   mobileDetailOpen = false;
   loading = true;
+
+  isAdmin = false;
+  orgLogoMap = new Map<string, string>();
+  private _uploadTargetOrg = '';
 
   statusFilter = 'All';
   statusOptions = [
@@ -82,6 +91,12 @@ export class JobsBoardComponent implements OnInit, OnDestroy {
     window.addEventListener('resize', this.resizeHandler);
     this.updateMetaTags();
     this.loadJobs();
+
+    this.userService.currentUser$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((user) => {
+        this.isAdmin = !!user?.admin;
+      });
   }
 
   ngOnDestroy(): void {
@@ -93,12 +108,15 @@ export class JobsBoardComponent implements OnInit, OnDestroy {
   }
 
   private loadJobs(): void {
-    this.jobService
-      .getAllJobs()
+    forkJoin({
+      jobs: this.jobService.getAllJobs(),
+      logos: this.jobService.getOrgLogos(),
+    })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (jobs) => {
+        next: ({ jobs, logos }) => {
           this.jobs = jobs;
+          this.orgLogoMap = buildOrgLogoMap(jobs, logos);
           this.buildRoleTypeOptions();
           this.applyFilters();
           this.loading = false;
@@ -169,6 +187,37 @@ export class JobsBoardComponent implements OnInit, OnDestroy {
       month: 'short',
       year: 'numeric',
     });
+  }
+
+  getLogoUrl(job: IJob): string | undefined {
+    return this.orgLogoMap.get(job.organisation.toLowerCase().trim());
+  }
+
+  onLogoUpload(job: IJob): void {
+    this._uploadTargetOrg = job.organisation;
+    this.logoFileInput.nativeElement.click();
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file || !this._uploadTargetOrg) return;
+
+    this.jobService
+      .uploadOrgLogo(file, this._uploadTargetOrg)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          const normalised = this._uploadTargetOrg.toLowerCase().trim();
+          this.orgLogoMap.set(normalised, res.data.logoUrl);
+          this._uploadTargetOrg = '';
+          input.value = '';
+        },
+        error: () => {
+          this._uploadTargetOrg = '';
+          input.value = '';
+        },
+      });
   }
 
   private updateMetaTags(): void {

--- a/frontend/src/app/routes/jobs-board/jobs-board.component.ts
+++ b/frontend/src/app/routes/jobs-board/jobs-board.component.ts
@@ -194,7 +194,7 @@ export class JobsBoardComponent implements OnInit, OnDestroy {
   }
 
   onIconClick(event: MouseEvent, job: IJob): void {
-    if (this.isAdmin && !this.getLogoUrl(job)) {
+    if (this.isAdmin) {
       event.stopPropagation();
       this.onLogoUpload(job);
     }

--- a/frontend/src/app/shared/models/v2/orgLogo.schema.ts
+++ b/frontend/src/app/shared/models/v2/orgLogo.schema.ts
@@ -1,0 +1,7 @@
+export interface IOrgLogo {
+  _id: string;
+  organisation: string;
+  logoUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/frontend/src/app/shared/services/api/jobs.api.service.ts
+++ b/frontend/src/app/shared/services/api/jobs.api.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { IJob } from '@models/job.schema';
+import { IOrgLogo } from '@models/orgLogo.schema';
 import { map, Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 
@@ -35,5 +36,30 @@ export class JobService {
     return this.http
       .get<Array<Record<string, unknown>>>(`${this.urlV2}/jobs`)
       .pipe(map((jobs) => jobs.map(mapRawJob)));
+  }
+
+  getOrgLogos(): Observable<IOrgLogo[]> {
+    return this.http.get<IOrgLogo[]>(`${this.urlV2}/jobs/logos`);
+  }
+
+  uploadOrgLogo(
+    file: File,
+    organisation: string
+  ): Observable<{ message: string; data: IOrgLogo }> {
+    const formData = new FormData();
+    formData.append('logo', file);
+    formData.append('organisation', organisation);
+    return this.http.put<{ message: string; data: IOrgLogo }>(
+      `${this.urlV2}/jobs/logos`,
+      formData,
+      { withCredentials: true }
+    );
+  }
+
+  deleteOrgLogo(organisation: string): Observable<{ message: string }> {
+    return this.http.delete<{ message: string }>(
+      `${this.urlV2}/jobs/logos/${encodeURIComponent(organisation)}`,
+      { withCredentials: true }
+    );
   }
 }

--- a/frontend/src/app/shared/utils/string-similarity.ts
+++ b/frontend/src/app/shared/utils/string-similarity.ts
@@ -45,7 +45,7 @@ export function buildOrgLogoMap(
   // Index logos by normalised name
   const logoIndex = new Map<string, string>();
   for (const logo of logos) {
-    logoIndex.set(logo.organisation, logo.logoUrl);
+    logoIndex.set(logo.organisation.toLowerCase().trim(), logo.logoUrl);
   }
 
   // Get unique org names from jobs

--- a/frontend/src/app/shared/utils/string-similarity.ts
+++ b/frontend/src/app/shared/utils/string-similarity.ts
@@ -1,0 +1,80 @@
+import { IOrgLogo } from '@models/orgLogo.schema';
+import { IJob } from '@models/job.schema';
+
+/**
+ * Computes the Dice coefficient between two strings.
+ * Returns a value between 0 (no similarity) and 1 (identical).
+ */
+export function compareTwoStrings(a: string, b: string): number {
+  const first = a.toLowerCase().trim();
+  const second = b.toLowerCase().trim();
+
+  if (first === second) return 1;
+  if (first.length < 2 || second.length < 2) return 0;
+
+  const bigramsA = new Map<string, number>();
+  for (let i = 0; i < first.length - 1; i++) {
+    const bigram = first.substring(i, i + 2);
+    bigramsA.set(bigram, (bigramsA.get(bigram) || 0) + 1);
+  }
+
+  let intersectionSize = 0;
+  for (let i = 0; i < second.length - 1; i++) {
+    const bigram = second.substring(i, i + 2);
+    const count = bigramsA.get(bigram) || 0;
+    if (count > 0) {
+      bigramsA.set(bigram, count - 1);
+      intersectionSize++;
+    }
+  }
+
+  return (2.0 * intersectionSize) / (first.length - 1 + (second.length - 1));
+}
+
+/**
+ * Builds a Map from normalised organisation name to logoUrl.
+ * Uses exact match first, then fuzzy fallback above the threshold.
+ */
+export function buildOrgLogoMap(
+  jobs: IJob[],
+  logos: IOrgLogo[],
+  threshold = 0.7
+): Map<string, string> {
+  const logoMap = new Map<string, string>();
+
+  // Index logos by normalised name
+  const logoIndex = new Map<string, string>();
+  for (const logo of logos) {
+    logoIndex.set(logo.organisation, logo.logoUrl);
+  }
+
+  // Get unique org names from jobs
+  const orgNames = new Set(jobs.map((j) => j.organisation));
+
+  for (const orgName of orgNames) {
+    const normalised = orgName.toLowerCase().trim();
+
+    // Exact match
+    if (logoIndex.has(normalised)) {
+      logoMap.set(normalised, logoIndex.get(normalised)!);
+      continue;
+    }
+
+    // Fuzzy fallback
+    let bestScore = 0;
+    let bestUrl = '';
+    for (const [logoOrg, url] of logoIndex) {
+      const score = compareTwoStrings(normalised, logoOrg);
+      if (score > bestScore) {
+        bestScore = score;
+        bestUrl = url;
+      }
+    }
+
+    if (bestScore >= threshold) {
+      logoMap.set(normalised, bestUrl);
+    }
+  }
+
+  return logoMap;
+}


### PR DESCRIPTION
For each job card an image of the club/student team can be shown, admins can modify this manually by uploading an image.

We use dice coefficient to check similarity between org names to show the same images.

New mongodb model introduced for this (OrgLogo).