### PR TITLE
Add opt-in commit-msg hook enforcing conventional commits

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Enforce Conventional Commits on the commit subject line.
+# https://www.conventionalcommits.org
+#
+# Enabled per-clone via `git config core.hooksPath .githooks` (run `make hooks`,
+# which `make install` does for you).
+
+subject="$(head -n1 "$1")"
+
+# Let git-generated commits (merge/revert) and fixup/squash commits through.
+case "$subject" in
+  "Merge "*|"Revert "*|fixup!*|squash!*) exit 0 ;;
+esac
+
+pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9 ._/-]+\))?!?: .+'
+
+if printf '%s' "$subject" | grep -Eq "$pattern"; then
+  exit 0
+fi
+
+echo "✗ Commit message is not a Conventional Commit." >&2
+echo >&2
+echo "  format: <type>[(scope)][!]: <subject>" >&2
+echo "  types:  feat fix docs style refactor perf test build ci chore revert" >&2
+echo "  e.g.    fix(backend): serve compiled JS for Vercel function" >&2
+echo >&2
+echo "  got:    $subject" >&2
+exit 1

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -7,12 +7,12 @@
 
 subject="$(head -n1 "$1")"
 
-# Let git-generated commits (merge/revert) and fixup/squash commits through.
+# Let git-generated commits (merge/revert) and fixup/squash/amend commits through.
 case "$subject" in
-  "Merge "*|"Revert "*|fixup!*|squash!*) exit 0 ;;
+  "Merge "*|"Revert "*|fixup!*|squash!*|amend!*) exit 0 ;;
 esac
 
-pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9 ._/-]+\))?!?: .+'
+pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9 ._/-]+\))?!?: .+'
 
 if printf '%s' "$subject" | grep -Eq "$pattern"; then
   exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ cd backend && node server.js
 
 ### Commit messages
 - Use [conventional commit messages](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3)
-- A `commit-msg` git hook enforces this locally — enable it with `make hooks` (or `make install`, which runs it for you).
+- A `commit-msg` git hook enforces this locally — enable it with `make hooks` (or `make install`, which runs it for you). Without make, run `git config core.hooksPath .githooks`.
 
 ### Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,7 @@ cd backend && node server.js
 
 ### Commit messages
 - Use [conventional commit messages](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3)
+- A `commit-msg` git hook enforces this locally — enable it with `make hooks` (or `make install`, which runs it for you).
 
 ### Pull Request Process
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-backend dev-frontend install install-backend install-frontend clean help
+.PHONY: dev dev-backend dev-frontend install install-backend install-frontend hooks clean help
 
 # Colors for help text
 BLUE := \033[0;34m
@@ -30,7 +30,7 @@ dev-frontend: ## Start only the frontend server
 
 ##@ Installation
 
-install: install-backend install-frontend ## Install dependencies for both frontend and backend
+install: install-backend install-frontend hooks ## Install dependencies for both frontend and backend
 	@echo "$(GREEN)All dependencies installed successfully!$(NC)"
 
 install-backend: ## Install backend dependencies
@@ -40,6 +40,10 @@ install-backend: ## Install backend dependencies
 install-frontend: ## Install frontend dependencies
 	@echo "$(GREEN)Installing frontend dependencies...$(NC)"
 	cd frontend && npm install
+
+hooks: ## Enable project git hooks (Conventional Commit message check)
+	@git config core.hooksPath .githooks
+	@echo "$(BLUE)Git hooks enabled (.githooks)$(NC)"
 
 ##@ Testing
 


### PR DESCRIPTION
Adds a dependency-free `commit-msg` hook that enforces Conventional Commits on the subject line.

- [.githooks/commit-msg](https://github.com/wiredmonash/monstar/blob/chore/commit-hooks/.githooks/commit-msg) validates `type(scope)!: subject` against the standard type set (`feat fix docs style refactor perf test build ci chore revert`); lets `Merge`/`Revert` and `fixup!`/`squash!`/`amend!` commits through.
- `make hooks` enables it per clone via `core.hooksPath` — [Makefile#L44-L46](https://github.com/wiredmonash/monstar/blob/chore/commit-hooks/Makefile#L44-L46). `make install` runs it automatically; without make: `git config core.hooksPath .githooks`.
- Setup documented in [CONTRIBUTING.md#L81](https://github.com/wiredmonash/monstar/blob/chore/commit-hooks/CONTRIBUTING.md#L81).
- Includes review fixes on top of the original hook: exempt `amend!` (autosquash) commits, allow uppercase scopes like `docs(README):`, and document the no-make fallback.
- Verified with an 18-case subject battery (accept/reject) plus a real `git commit` end-to-end run against the hook.

Local check only (bypassable with `--no-verify`); a CI commitlint step can add a hard gate on PRs later if wanted.
