### PR TITLE
Share agent skills in-repo with Angular 18 forks

### DIFF
--- a/.agents/skills/angular-component/SKILL.md
+++ b/.agents/skills/angular-component/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: angular-component
+description: Create modern Angular standalone components following v18 best practices. Use for building UI components with signal-based inputs/outputs, OnPush change detection, host bindings, content projection, and lifecycle hooks. Triggers on component creation, refactoring class-based inputs to signals, adding host bindings, or implementing accessible interactive components.
+---
+
+# Angular Component
+
+Create standalone components for Angular v18. Always set `standalone: true` explicitly—components are only standalone by default from v19 onward, so omitting it in v18 silently creates an NgModule-style component that breaks when imported. Signal-based `input()`/`output()` are developer preview in v18 but the API is identical to later versions—use them.
+
+## Component Structure
+
+```typescript
+import { Component, ChangeDetectionStrategy, input, output, computed } from '@angular/core';
+
+@Component({
+  selector: 'app-user-card',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    'class': 'user-card',
+    '[class.active]': 'isActive()',
+    '(click)': 'handleClick()',
+  },
+  template: `
+    <img [src]="avatarUrl()" [alt]="name() + ' avatar'" />
+    <h2>{{ name() }}</h2>
+    @if (showEmail()) {
+      <p>{{ email() }}</p>
+    }
+  `,
+  styles: `
+    :host { display: block; }
+    :host.active { border: 2px solid blue; }
+  `,
+})
+export class UserCard {
+  // Required input
+  name = input.required<string>();
+  
+  // Optional input with default
+  email = input<string>('');
+  showEmail = input(false);
+  
+  // Input with transform
+  isActive = input(false, { transform: booleanAttribute });
+  
+  // Computed from inputs
+  avatarUrl = computed(() => `https://api.example.com/avatar/${this.name()}`);
+  
+  // Output
+  selected = output<string>();
+  
+  handleClick() {
+    this.selected.emit(this.name());
+  }
+}
+```
+
+## Signal Inputs
+
+```typescript
+// Required - must be provided by parent
+name = input.required<string>();
+
+// Optional with default value
+count = input(0);
+
+// Optional without default (undefined allowed)
+label = input<string>();
+
+// With alias for template binding
+size = input('medium', { alias: 'buttonSize' });
+
+// With transform function
+disabled = input(false, { transform: booleanAttribute });
+value = input(0, { transform: numberAttribute });
+```
+
+## Signal Outputs
+
+```typescript
+import { output, outputFromObservable } from '@angular/core';
+
+// Basic output
+clicked = output<void>();
+selected = output<Item>();
+
+// With alias
+valueChange = output<number>({ alias: 'change' });
+
+// From Observable (for RxJS interop)
+scroll$ = new Subject<number>();
+scrolled = outputFromObservable(this.scroll$);
+
+// Emit values
+this.clicked.emit();
+this.selected.emit(item);
+```
+
+## Host Bindings
+
+Use the `host` object in `@Component`—do NOT use `@HostBinding` or `@HostListener` decorators.
+
+```typescript
+@Component({
+  selector: 'app-button',
+  standalone: true,
+  host: {
+    // Static attributes
+    'role': 'button',
+    
+    // Dynamic class bindings
+    '[class.primary]': 'variant() === "primary"',
+    '[class.disabled]': 'disabled()',
+    
+    // Dynamic style bindings
+    '[style.--btn-color]': 'color()',
+    
+    // Attribute bindings
+    '[attr.aria-disabled]': 'disabled()',
+    '[attr.tabindex]': 'disabled() ? -1 : 0',
+    
+    // Event listeners
+    '(click)': 'onClick($event)',
+    '(keydown.enter)': 'onClick($event)',
+    '(keydown.space)': 'onClick($event)',
+  },
+  template: `<ng-content />`,
+})
+export class Button {
+  variant = input<'primary' | 'secondary'>('primary');
+  disabled = input(false, { transform: booleanAttribute });
+  color = input('#007bff');
+  
+  clicked = output<void>();
+  
+  onClick(event: Event) {
+    if (!this.disabled()) {
+      this.clicked.emit();
+    }
+  }
+}
+```
+
+## Content Projection
+
+```typescript
+@Component({
+  selector: 'app-card',
+  standalone: true,
+  template: `
+    <header>
+      <ng-content select="[card-header]" />
+    </header>
+    <main>
+      <ng-content />
+    </main>
+    <footer>
+      <ng-content select="[card-footer]" />
+    </footer>
+  `,
+})
+export class Card {}
+
+// Usage:
+// <app-card>
+//   <h2 card-header>Title</h2>
+//   <p>Main content</p>
+//   <button card-footer>Action</button>
+// </app-card>
+```
+
+## Lifecycle Hooks
+
+```typescript
+import { OnDestroy, OnInit, afterNextRender, afterRender } from '@angular/core';
+
+export class My implements OnInit, OnDestroy {
+  constructor() {
+    // For DOM manipulation after render (SSR-safe)
+    afterNextRender(() => {
+      // Runs once after first render
+    });
+
+    afterRender(() => {
+      // Runs after every render
+    });
+  }
+
+  ngOnInit() { /* Component initialized */ }
+  ngOnDestroy() { /* Cleanup */ }
+}
+```
+
+## Accessibility Requirements
+
+Components MUST:
+- Pass AXE accessibility checks
+- Meet WCAG AA standards
+- Include proper ARIA attributes for interactive elements
+- Support keyboard navigation
+- Maintain visible focus indicators
+
+```typescript
+@Component({
+  selector: 'app-toggle',
+  standalone: true,
+  host: {
+    'role': 'switch',
+    '[attr.aria-checked]': 'checked()',
+    '[attr.aria-label]': 'label()',
+    'tabindex': '0',
+    '(click)': 'toggle()',
+    '(keydown.enter)': 'toggle()',
+    '(keydown.space)': 'toggle(); $event.preventDefault()',
+  },
+  template: `<span class="toggle-track"><span class="toggle-thumb"></span></span>`,
+})
+export class Toggle {
+  label = input.required<string>();
+  checked = input(false, { transform: booleanAttribute });
+  checkedChange = output<boolean>();
+  
+  toggle() {
+    this.checkedChange.emit(!this.checked());
+  }
+}
+```
+
+## Template Syntax
+
+Use native control flow—do NOT use `*ngIf`, `*ngFor`, `*ngSwitch`.
+
+```html
+<!-- Conditionals -->
+@if (isLoading()) {
+  <app-spinner />
+} @else if (error()) {
+  <app-error [message]="error()" />
+} @else {
+  <app-content [data]="data()" />
+}
+
+<!-- Loops -->
+@for (item of items(); track item.id) {
+  <app-item [item]="item" />
+} @empty {
+  <p>No items found</p>
+}
+
+<!-- Switch -->
+@switch (status()) {
+  @case ('pending') { <span>Pending</span> }
+  @case ('active') { <span>Active</span> }
+  @default { <span>Unknown</span> }
+}
+```
+
+## Class and Style Bindings
+
+Do NOT use `ngClass` or `ngStyle`. Use direct bindings:
+
+```html
+<!-- Class bindings -->
+<div [class.active]="isActive()">Single class</div>
+<div [class]="classString()">Class string</div>
+
+<!-- Style bindings -->
+<div [style.color]="textColor()">Styled text</div>
+<div [style.width.px]="width()">With unit</div>
+```
+
+## Images
+
+Use `NgOptimizedImage` for static images:
+
+```typescript
+import { NgOptimizedImage } from '@angular/common';
+
+@Component({
+  standalone: true,
+  imports: [NgOptimizedImage],
+  template: `
+    <img ngSrc="/assets/hero.jpg" width="800" height="600" priority />
+    <img [ngSrc]="imageUrl()" width="200" height="200" />
+  `,
+})
+export class Hero {
+  imageUrl = input.required<string>();
+}
+```
+
+For detailed patterns, see [references/component-patterns.md](references/component-patterns.md).

--- a/.agents/skills/angular-component/references/component-patterns.md
+++ b/.agents/skills/angular-component/references/component-patterns.md
@@ -1,0 +1,370 @@
+# Angular Component Patterns
+
+## Table of Contents
+- [Model Inputs (Two-Way Binding)](#model-inputs-two-way-binding)
+- [View Queries](#view-queries)
+- [Content Queries](#content-queries)
+- [Dependency Injection in Components](#dependency-injection-in-components)
+- [Component Communication Patterns](#component-communication-patterns)
+- [Dynamic Components](#dynamic-components)
+
+## Model Inputs (Two-Way Binding)
+
+For two-way binding with `[(value)]` syntax:
+
+```typescript
+import { Component, model } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-slider',
+  host: {
+    '(input)': 'onInput($event)',
+  },
+  template: `
+    <input 
+      type="range" 
+      [value]="value()" 
+      [min]="min()" 
+      [max]="max()" 
+    />
+    <span>{{ value() }}</span>
+  `,
+})
+export class Slider {
+  // Model creates both input and output
+  value = model(0);
+  min = input(0);
+  max = input(100);
+  
+  onInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.value.set(Number(target.value));
+  }
+}
+
+// Usage: <app-slider [(value)]="sliderValue" />
+```
+
+Required model:
+
+```typescript
+value = model.required<number>();
+```
+
+## View Queries
+
+Query elements and components in the template:
+
+```typescript
+import { Component, viewChild, viewChildren, ElementRef } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-gallery',
+  template: `
+    <div #container class="gallery">
+      @for (image of images(); track image.id) {
+        <app-image-card [image]="image" />
+      }
+    </div>
+  `,
+})
+export class Gallery {
+  images = input.required<Image[]>();
+
+  // Query single element
+  container = viewChild.required<ElementRef<HTMLDivElement>>('container');
+
+  // Query single component (optional)
+  firstCard = viewChild(ImageCard);
+
+  // Query all matching components
+  allCards = viewChildren(ImageCard);
+}
+```
+
+## Content Queries
+
+Query projected content:
+
+```typescript
+import { Component, contentChild, contentChildren, effect, signal } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-tabs',
+  template: `
+    <div class="tab-headers">
+      @for (tab of tabs(); track tab.label()) {
+        <button
+          [class.active]="tab === activeTab()"
+          (click)="selectTab(tab)"
+        >
+          {{ tab.label() }}
+        </button>
+      }
+    </div>
+    <div class="tab-content">
+      <ng-content />
+    </div>
+  `,
+})
+export class Tabs {
+  // Query all projected Tab children
+  tabs = contentChildren(Tab);
+
+  // Query single projected element
+  header = contentChild('tabHeader');
+
+  activeTab = signal<Tab | undefined>(undefined);
+
+  constructor() {
+    // Set first tab as active when tabs are available
+    effect(() => {
+      const firstTab = this.tabs()[0];
+      if (firstTab && !this.activeTab()) {
+        this.activeTab.set(firstTab);
+      }
+    });
+  }
+
+  selectTab(tab: Tab) {
+    this.activeTab.set(tab);
+  }
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-tab',
+  template: `<ng-content />`,
+  host: {
+    '[class.active]': 'isActive()',
+    '[style.display]': 'isActive() ? "block" : "none"',
+  },
+})
+export class Tab {
+  label = input.required<string>();
+  isActive = input(false);
+}
+```
+
+## Dependency Injection in Components
+
+Use `inject()` function instead of constructor injection:
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  standalone: true,
+  selector: 'app-dashboard',
+  template: `...`,
+})
+export class Dashboard {
+  private router = inject(Router);
+  private userService = inject(User);
+  private config = inject(APP_CONFIG);
+  
+  // Optional injection
+  private analytics = inject(Analytics, { optional: true });
+  
+  // Self-only injection
+  private localService = inject(Local, { self: true });
+  
+  navigateToProfile() {
+    this.router.navigate(['/profile']);
+  }
+}
+```
+
+## Component Communication Patterns
+
+### Parent to Child (Inputs)
+
+```typescript
+// Parent
+@Component({
+  standalone: true,
+  template: `<app-child [data]="parentData()" [config]="config" />`,
+})
+export class Parent {
+  parentData = signal({ name: 'Test' });
+  config = { theme: 'dark' };
+}
+
+// Child
+@Component({ selector: 'app-child', standalone: true })
+export class Child {
+  data = input.required<Data>();
+  config = input<Config>();
+}
+```
+
+### Child to Parent (Outputs)
+
+```typescript
+// Child
+@Component({
+  standalone: true,
+  selector: 'app-child',
+  template: `<button (click)="save()">Save</button>`,
+})
+export class Child {
+  saved = output<Data>();
+  
+  save() {
+    this.saved.emit({ id: 1, name: 'Item' });
+  }
+}
+
+// Parent
+@Component({
+  standalone: true,
+  template: `<app-child (saved)="onSaved($event)" />`,
+})
+export class Parent {
+  onSaved(data: Data) {
+    console.log('Saved:', data);
+  }
+}
+```
+
+### Shared Service Pattern
+
+```typescript
+// Shared state service
+@Injectable({ providedIn: 'root' })
+export class Cart {
+  private items = signal<CartItem[]>([]);
+  
+  readonly items$ = this.items.asReadonly();
+  readonly total = computed(() => 
+    this.items().reduce((sum, item) => sum + item.price, 0)
+  );
+  
+  addItem(item: CartItem) {
+    this.items.update(items => [...items, item]);
+  }
+  
+  removeItem(id: string) {
+    this.items.update(items => items.filter(i => i.id !== id));
+  }
+}
+
+// Component A
+@Component({ template: `<button (click)="add()">Add</button>` })
+export class Product {
+  private cart = inject(Cart);
+  product = input.required<Product>();
+  
+  add() {
+    this.cart.addItem({ ...this.product(), quantity: 1 });
+  }
+}
+
+// Component B
+@Component({ template: `<span>Total: {{ cart.total() }}</span>` })
+export class CartSummary {
+  cart = inject(Cart);
+}
+```
+
+## Dynamic Components
+
+Using `@defer` for lazy loading:
+
+```typescript
+@Component({
+  standalone: true,
+  template: `
+    @defer (on viewport) {
+      <app-heavy-chart [data]="chartData()" />
+    } @placeholder {
+      <div class="chart-placeholder">Loading chart...</div>
+    } @loading (minimum 500ms) {
+      <app-spinner />
+    } @error {
+      <p>Failed to load chart</p>
+    }
+  `,
+})
+export class Dashboard {
+  chartData = input.required<ChartData>();
+}
+```
+
+Defer triggers:
+- `on viewport` - When element enters viewport
+- `on idle` - When browser is idle
+- `on interaction` - On user interaction (click, focus)
+- `on hover` - On mouse hover
+- `on immediate` - Immediately after non-deferred content
+- `on timer(500ms)` - After specified delay
+- `when condition` - When expression becomes true
+
+```typescript
+@Component({
+  standalone: true,
+  template: `
+    @defer (on interaction; prefetch on idle) {
+      <app-comments [postId]="postId()" />
+    } @placeholder {
+      <button>Load Comments</button>
+    }
+  `,
+})
+export class Post {
+  postId = input.required<string>();
+}
+```
+
+## Attribute Directives on Components
+
+```typescript
+@Directive({
+  selector: '[appHighlight]',
+  host: {
+    '[style.backgroundColor]': 'color()',
+  },
+})
+export class Highlight {
+  color = input('yellow', { alias: 'appHighlight' });
+}
+
+// Usage on component
+@Component({
+  standalone: true,
+  imports: [Highlight],
+  template: `<app-card appHighlight="lightblue" />`,
+})
+export class Page {}
+```
+
+## Error Boundaries
+
+```typescript
+@Component({
+  standalone: true,
+  selector: 'app-error-boundary',
+  template: `
+    @if (hasError()) {
+      <div class="error">
+        <h3>Something went wrong</h3>
+        <button (click)="retry()">Retry</button>
+      </div>
+    } @else {
+      <ng-content />
+    }
+  `,
+})
+export class ErrorBoundary {
+  hasError = signal(false);
+  private errorHandler = inject(ErrorHandler);
+  
+  retry() {
+    this.hasError.set(false);
+  }
+}
+```

--- a/.agents/skills/angular-routing/SKILL.md
+++ b/.agents/skills/angular-routing/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: angular-routing
+description: Implement routing in Angular v18 applications with lazy loading, functional guards, resolvers, and route parameters. Use for navigation setup, protected routes, route-based data loading, and nested routing. Triggers on route configuration, adding authentication guards, implementing lazy loading, or reading route parameters with signals.
+---
+
+# Angular Routing
+
+Configure routing in Angular v18 with lazy loading, functional guards, and signal-based route parameters.
+
+## Basic Setup
+
+```typescript
+// app.routes.ts
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [
+  { path: '', redirectTo: '/home', pathMatch: 'full' },
+  { path: 'home', component: Home },
+  { path: 'about', component: About },
+  { path: '**', component: NotFound },
+];
+
+// app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes),
+  ],
+};
+
+// app.component.ts
+import { Component } from '@angular/core';
+import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  template: `
+    <nav>
+      <a routerLink="/home" routerLinkActive="active">Home</a>
+      <a routerLink="/about" routerLinkActive="active">About</a>
+    </nav>
+    <router-outlet />
+  `,
+})
+export class App {}
+```
+
+## Lazy Loading
+
+Load feature modules on demand:
+
+```typescript
+// app.routes.ts
+export const routes: Routes = [
+  { path: '', redirectTo: '/home', pathMatch: 'full' },
+  { path: 'home', component: Home },
+  
+  // Lazy load entire feature
+  {
+    path: 'admin',
+    loadChildren: () => import('./admin/admin.routes').then(m => m.adminRoutes),
+  },
+  
+  // Lazy load single component
+  {
+    path: 'settings',
+    loadComponent: () => import('./settings/settings.component').then(m => m.Settings),
+  },
+];
+
+// admin/admin.routes.ts
+export const adminRoutes: Routes = [
+  { path: '', component: AdminDashboard },
+  { path: 'users', component: AdminUsers },
+  { path: 'settings', component: AdminSettings },
+];
+```
+
+## Route Parameters
+
+### With Signal Inputs (Recommended)
+
+```typescript
+// Route config
+{ path: 'users/:id', component: UserDetail }
+
+// Component - use input() for route params
+import { Component, input, computed } from '@angular/core';
+
+@Component({
+  selector: 'app-user-detail',
+  template: `
+    <h1>User {{ id() }}</h1>
+  `,
+})
+export class UserDetail {
+  // Route param as signal input
+  id = input.required<string>();
+  
+  // Computed based on route param
+  userId = computed(() => parseInt(this.id(), 10));
+}
+```
+
+Enable with `withComponentInputBinding()`:
+
+```typescript
+// app.config.ts
+import { provideRouter, withComponentInputBinding } from '@angular/router';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes, withComponentInputBinding()),
+  ],
+};
+```
+
+### Query Parameters
+
+```typescript
+// Route: /search?q=angular&page=1
+
+@Component({...})
+export class Search {
+  // Query params as inputs
+  q = input<string>('');
+  page = input<string>('1');
+  
+  currentPage = computed(() => parseInt(this.page(), 10));
+}
+```
+
+### With ActivatedRoute (Alternative)
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+
+@Component({...})
+export class UserDetail {
+  private route = inject(ActivatedRoute);
+  
+  // Convert route params to signal
+  id = toSignal(
+    this.route.paramMap.pipe(map(params => params.get('id'))),
+    { initialValue: null }
+  );
+  
+  // Query params
+  query = toSignal(
+    this.route.queryParamMap.pipe(map(params => params.get('q'))),
+    { initialValue: '' }
+  );
+}
+```
+
+## Functional Guards
+
+### Auth Guard
+
+```typescript
+// guards/auth.guard.ts
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const authService = inject(Auth);
+  const router = inject(Router);
+  
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+  
+  // Redirect to login with return URL
+  return router.createUrlTree(['/login'], {
+    queryParams: { returnUrl: state.url },
+  });
+};
+
+// Usage in routes
+{
+  path: 'dashboard',
+  component: Dashboard,
+  canActivate: [authGuard],
+}
+```
+
+### Role Guard
+
+```typescript
+export const roleGuard = (allowedRoles: string[]): CanActivateFn => {
+  return (route, state) => {
+    const authService = inject(Auth);
+    const router = inject(Router);
+    
+    const userRole = authService.currentUser()?.role;
+    
+    if (userRole && allowedRoles.includes(userRole)) {
+      return true;
+    }
+    
+    return router.createUrlTree(['/unauthorized']);
+  };
+};
+
+// Usage
+{
+  path: 'admin',
+  component: Admin,
+  canActivate: [authGuard, roleGuard(['admin', 'superadmin'])],
+}
+```
+
+### Can Deactivate Guard
+
+```typescript
+export interface CanDeactivate {
+  canDeactivate: () => boolean | Promise<boolean>;
+}
+
+export const unsavedChangesGuard: CanDeactivateFn<CanDeactivate> = (component) => {
+  if (component.canDeactivate()) {
+    return true;
+  }
+  
+  return confirm('You have unsaved changes. Leave anyway?');
+};
+
+// Component implementation
+@Component({...})
+export class Edit implements CanDeactivate {
+  form = inject(FormBuilder).group({...});
+  
+  canDeactivate(): boolean {
+    return !this.form.dirty;
+  }
+}
+
+// Route
+{
+  path: 'edit/:id',
+  component: Edit,
+  canDeactivate: [unsavedChangesGuard],
+}
+```
+
+## Resolvers
+
+Pre-fetch data before route activation:
+
+```typescript
+// resolvers/user.resolver.ts
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+
+export const userResolver: ResolveFn<User> = (route) => {
+  const userService = inject(User);
+  const id = route.paramMap.get('id')!;
+  return userService.getById(id);
+};
+
+// Route config
+{
+  path: 'users/:id',
+  component: UserDetail,
+  resolve: { user: userResolver },
+}
+
+// Component - access resolved data via input
+@Component({...})
+export class UserDetail {
+  user = input.required<User>();
+}
+```
+
+## Nested Routes
+
+```typescript
+// Parent route with children
+export const routes: Routes = [
+  {
+    path: 'products',
+    component: ProductsLayout,
+    children: [
+      { path: '', component: ProductList },
+      { path: ':id', component: ProductDetail },
+      { path: ':id/edit', component: ProductEdit },
+    ],
+  },
+];
+
+// ProductsLayout
+@Component({
+  imports: [RouterOutlet],
+  template: `
+    <h1>Products</h1>
+    <router-outlet /> <!-- Child routes render here -->
+  `,
+})
+export class ProductsLayout {}
+```
+
+## Programmatic Navigation
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({...})
+export class Product {
+  private router = inject(Router);
+  
+  // Navigate to route
+  goToProducts() {
+    this.router.navigate(['/products']);
+  }
+  
+  // Navigate with params
+  goToProduct(id: string) {
+    this.router.navigate(['/products', id]);
+  }
+  
+  // Navigate with query params
+  search(query: string) {
+    this.router.navigate(['/search'], {
+      queryParams: { q: query, page: 1 },
+    });
+  }
+  
+  // Navigate relative to current route
+  goToEdit() {
+    this.router.navigate(['edit'], { relativeTo: this.route });
+  }
+  
+  // Replace current history entry
+  replaceUrl() {
+    this.router.navigate(['/new-page'], { replaceUrl: true });
+  }
+}
+```
+
+## Route Data
+
+```typescript
+// Static route data
+{
+  path: 'admin',
+  component: Admin,
+  data: {
+    title: 'Admin Dashboard',
+    roles: ['admin'],
+  },
+}
+
+// Access in component
+@Component({...})
+export class AdminCmpt {
+  title = input<string>(); // From route data
+  roles = input<string[]>(); // From route data
+}
+
+// Or via ActivatedRoute
+private route = inject(ActivatedRoute);
+data = toSignal(this.route.data);
+```
+
+## Router Events
+
+```typescript
+import { Router, NavigationStart, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs';
+
+@Component({...})
+export class AppMain {
+  private router = inject(Router);
+  
+  isNavigating = signal(false);
+  
+  constructor() {
+    this.router.events.pipe(
+      filter(e => e instanceof NavigationStart || e instanceof NavigationEnd)
+    ).subscribe(event => {
+      this.isNavigating.set(event instanceof NavigationStart);
+    });
+  }
+}
+```
+
+For advanced patterns, see [references/routing-patterns.md](references/routing-patterns.md).

--- a/.agents/skills/angular-routing/references/routing-patterns.md
+++ b/.agents/skills/angular-routing/references/routing-patterns.md
@@ -1,0 +1,477 @@
+# Angular Routing Patterns
+
+## Table of Contents
+- [Route Configuration Options](#route-configuration-options)
+- [Authentication Flow](#authentication-flow)
+- [Breadcrumbs](#breadcrumbs)
+- [Tab Navigation](#tab-navigation)
+- [Modal Routes](#modal-routes)
+- [Preloading Strategies](#preloading-strategies)
+
+## Route Configuration Options
+
+### Full Route Options
+
+```typescript
+{
+  path: 'users/:id',
+  component: UserCmpt,
+  
+  // Lazy loading alternatives
+  loadComponent: () => import('./user.component').then(m => m.UserCmpt),
+  loadChildren: () => import('./user.routes').then(m => m.userRoutes),
+  
+  // Guards
+  canActivate: [authGuard],
+  canActivateChild: [authGuard],
+  canDeactivate: [unsavedChangesGuard],
+  canMatch: [featureFlagGuard],
+  
+  // Data
+  resolve: { user: userResolver },
+  data: { title: 'User Profile', animation: 'userPage' },
+  
+  // Children
+  children: [...],
+  
+  // Outlet
+  outlet: 'sidebar',
+  
+  // Path matching
+  pathMatch: 'full', // or 'prefix'
+  
+  // Title
+  title: 'User Profile',
+  // Or dynamic title
+  title: userTitleResolver,
+}
+```
+
+### Dynamic Title Resolver
+
+```typescript
+export const userTitleResolver: ResolveFn<string> = (route) => {
+  const userService = inject(User);
+  const id = route.paramMap.get('id')!;
+  return userService.getById(id).pipe(
+    map(user => `${user.name} - Profile`)
+  );
+};
+```
+
+## Authentication Flow
+
+### Complete Auth Setup
+
+```typescript
+// auth.service.ts
+@Injectable({ providedIn: 'root' })
+export class Auth {
+  private _user = signal<User | null>(null);
+  private _token = signal<string | null>(null);
+  
+  readonly user = this._user.asReadonly();
+  readonly isAuthenticated = computed(() => this._user() !== null);
+  
+  private router = inject(Router);
+  private http = inject(HttpClient);
+  
+  async login(credentials: Credentials): Promise<boolean> {
+    try {
+      const response = await firstValueFrom(
+        this.http.post<AuthResponse>('/api/login', credentials)
+      );
+      
+      this._token.set(response.token);
+      this._user.set(response.user);
+      localStorage.setItem('token', response.token);
+      
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  
+  logout(): void {
+    this._user.set(null);
+    this._token.set(null);
+    localStorage.removeItem('token');
+    this.router.navigate(['/login']);
+  }
+  
+  async checkAuth(): Promise<boolean> {
+    const token = localStorage.getItem('token');
+    if (!token) return false;
+    
+    try {
+      const user = await firstValueFrom(
+        this.http.get<User>('/api/me')
+      );
+      this._user.set(user);
+      this._token.set(token);
+      return true;
+    } catch {
+      localStorage.removeItem('token');
+      return false;
+    }
+  }
+}
+
+// auth.guard.ts
+export const authGuard: CanActivateFn = async (route, state) => {
+  const authService = inject(Auth);
+  const router = inject(Router);
+  
+  // Check if already authenticated
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+  
+  // Try to restore session
+  const isValid = await authService.checkAuth();
+  if (isValid) {
+    return true;
+  }
+  
+  // Redirect to login
+  return router.createUrlTree(['/login'], {
+    queryParams: { returnUrl: state.url },
+  });
+};
+
+// login.component.ts
+@Component({
+  standalone: true,
+  template: `
+    <form (ngSubmit)="login()">
+      <input [(ngModel)]="email" name="email" />
+      <input [(ngModel)]="password" name="password" type="password" />
+      <button type="submit">Login</button>
+    </form>
+  `,
+})
+export class Login {
+  private authService = inject(Auth);
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
+  
+  email = '';
+  password = '';
+  
+  async login() {
+    const success = await this.authService.login({
+      email: this.email,
+      password: this.password,
+    });
+    
+    if (success) {
+      const returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/';
+      this.router.navigateByUrl(returnUrl);
+    }
+  }
+}
+```
+
+## Breadcrumbs
+
+```typescript
+// breadcrumb.service.ts
+@Injectable({ providedIn: 'root' })
+export class Breadcrumb {
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
+  
+  breadcrumbs = toSignal(
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd),
+      map(() => this.buildBreadcrumbs(this.route.root))
+    ),
+    { initialValue: [] }
+  );
+  
+  private buildBreadcrumbs(
+    route: ActivatedRoute,
+    url: string = '',
+    breadcrumbs: Breadcrumb[] = []
+  ): Breadcrumb[] {
+    const children = route.children;
+    
+    if (children.length === 0) {
+      return breadcrumbs;
+    }
+    
+    for (const child of children) {
+      const routeUrl = child.snapshot.url
+        .map(segment => segment.path)
+        .join('/');
+      
+      if (routeUrl) {
+        url += `/${routeUrl}`;
+      }
+      
+      const label = child.snapshot.data['breadcrumb'];
+      if (label) {
+        breadcrumbs.push({ label, url });
+      }
+      
+      return this.buildBreadcrumbs(child, url, breadcrumbs);
+    }
+    
+    return breadcrumbs;
+  }
+}
+
+// Route config with breadcrumb data
+export const routes: Routes = [
+  {
+    path: 'products',
+    data: { breadcrumb: 'Products' },
+    children: [
+      { path: '', component: ProductList },
+      {
+        path: ':id',
+        data: { breadcrumb: 'Product Details' },
+        component: ProductDetail,
+      },
+    ],
+  },
+];
+
+// breadcrumb.component.ts
+@Component({
+  standalone: true,
+  selector: 'app-breadcrumb',
+  template: `
+    <nav aria-label="Breadcrumb">
+      <ol>
+        <li><a routerLink="/">Home</a></li>
+        @for (crumb of breadcrumbService.breadcrumbs(); track crumb.url) {
+          <li>
+            <a [routerLink]="crumb.url">{{ crumb.label }}</a>
+          </li>
+        }
+      </ol>
+    </nav>
+  `,
+})
+export class BreadcrumbCmpt {
+  breadcrumbService = inject(Breadcrumb);
+}
+```
+
+## Tab Navigation
+
+```typescript
+// tabs-layout.component.ts
+@Component({
+  standalone: true,
+  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  template: `
+    <div class="tabs">
+      @for (tab of tabs; track tab.path) {
+        <a 
+          [routerLink]="tab.path" 
+          routerLinkActive="active"
+          [routerLinkActiveOptions]="{ exact: tab.exact }"
+        >
+          {{ tab.label }}
+        </a>
+      }
+    </div>
+    <div class="tab-content">
+      <router-outlet />
+    </div>
+  `,
+})
+export class TabsLayout {
+  tabs = [
+    { path: './', label: 'Overview', exact: true },
+    { path: 'details', label: 'Details', exact: false },
+    { path: 'settings', label: 'Settings', exact: false },
+  ];
+}
+
+// Routes
+{
+  path: 'account',
+  component: TabsLayout,
+  children: [
+    { path: '', component: AccountOverview },
+    { path: 'details', component: AccountDetails },
+    { path: 'settings', component: AccountSettings },
+  ],
+}
+```
+
+## Modal Routes
+
+Using auxiliary outlets for modals:
+
+```typescript
+// Routes
+export const routes: Routes = [
+  { path: 'products', component: ProductList },
+  { path: 'product-modal/:id', component: ProductModal, outlet: 'modal' },
+];
+
+// App template
+@Component({
+  standalone: true,
+  template: `
+    <router-outlet />
+    <router-outlet name="modal" />
+  `,
+})
+export class App {}
+
+// Open modal
+this.router.navigate([{ outlets: { modal: ['product-modal', productId] } }]);
+
+// Close modal
+this.router.navigate([{ outlets: { modal: null } }]);
+
+// Link to open modal
+<a [routerLink]="[{ outlets: { modal: ['product-modal', product.id] } }]">
+  View Details
+</a>
+```
+
+## Preloading Strategies
+
+### Built-in Strategies
+
+```typescript
+import { 
+  provideRouter, 
+  withPreloading,
+  PreloadAllModules,
+  NoPreloading 
+} from '@angular/router';
+
+// Preload all lazy modules
+provideRouter(routes, withPreloading(PreloadAllModules))
+
+// No preloading (default)
+provideRouter(routes, withPreloading(NoPreloading))
+```
+
+### Custom Preloading Strategy
+
+```typescript
+// selective-preload.strategy.ts
+@Injectable({ providedIn: 'root' })
+export class SelectivePreloadStrategy implements PreloadingStrategy {
+  preload(route: Route, load: () => Observable<any>): Observable<any> {
+    // Only preload routes marked with data.preload = true
+    if (route.data?.['preload']) {
+      return load();
+    }
+    return of(null);
+  }
+}
+
+// Routes
+{
+  path: 'dashboard',
+  loadComponent: () => import('./dashboard.component'),
+  data: { preload: true }, // Will be preloaded
+}
+
+// Config
+provideRouter(routes, withPreloading(SelectivePreloadStrategy))
+```
+
+### Network-Aware Preloading
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class NetworkAwarePreloadStrategy implements PreloadingStrategy {
+  preload(route: Route, load: () => Observable<any>): Observable<any> {
+    // Check network conditions
+    const connection = (navigator as any).connection;
+    
+    if (connection) {
+      // Don't preload on slow connections
+      if (connection.saveData || connection.effectiveType === '2g') {
+        return of(null);
+      }
+    }
+    
+    // Preload if marked
+    if (route.data?.['preload']) {
+      return load();
+    }
+    
+    return of(null);
+  }
+}
+```
+
+## Route Animations
+
+```typescript
+// app.routes.ts
+export const routes: Routes = [
+  { path: 'home', component: Home, data: { animation: 'HomePage' } },
+  { path: 'about', component: About, data: { animation: 'AboutPage' } },
+];
+
+// app.component.ts
+@Component({
+  standalone: true,
+  imports: [RouterOutlet],
+  template: `
+    <div [@routeAnimations]="getRouteAnimationData()">
+      <router-outlet />
+    </div>
+  `,
+  animations: [
+    trigger('routeAnimations', [
+      transition('HomePage <=> AboutPage', [
+        style({ position: 'relative' }),
+        query(':enter, :leave', [
+          style({
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+          }),
+        ]),
+        query(':enter', [style({ left: '-100%' })]),
+        query(':leave', animateChild()),
+        group([
+          query(':leave', [animate('300ms ease-out', style({ left: '100%' }))]),
+          query(':enter', [animate('300ms ease-out', style({ left: '0%' }))]),
+        ]),
+      ]),
+    ]),
+  ],
+})
+export class AppMain {
+  getRouteAnimationData() {
+    return this.route.firstChild?.snapshot.data['animation'];
+  }
+}
+```
+
+## Scroll Position Restoration
+
+```typescript
+// app.config.ts
+import { 
+  provideRouter, 
+  withInMemoryScrolling,
+  withRouterConfig 
+} from '@angular/router';
+
+provideRouter(
+  routes,
+  withInMemoryScrolling({
+    scrollPositionRestoration: 'enabled', // or 'top'
+    anchorScrolling: 'enabled',
+  }),
+  withRouterConfig({
+    onSameUrlNavigation: 'reload',
+  })
+)
+```

--- a/.agents/skills/angular-signals/SKILL.md
+++ b/.agents/skills/angular-signals/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: angular-signals
+description: Implement signal-based reactive state management in Angular v18. Use for creating reactive state with signal(), derived state with computed(), and side effects with effect(). Triggers on state management questions, converting from BehaviorSubject/Observable patterns to signals, or implementing reactive data flows.
+---
+
+# Angular Signals
+
+Signals are Angular's reactive primitive for state management. They provide synchronous, fine-grained reactivity.
+
+## Core Signal APIs
+
+### signal() - Writable State
+
+```typescript
+import { signal } from '@angular/core';
+
+// Create writable signal
+const count = signal(0);
+
+// Read value
+console.log(count()); // 0
+
+// Set new value
+count.set(5);
+
+// Update based on current value
+count.update(c => c + 1);
+
+// With explicit type
+const user = signal<User | null>(null);
+user.set({ id: 1, name: 'Alice' });
+```
+
+### computed() - Derived State
+
+```typescript
+import { signal, computed } from '@angular/core';
+
+const firstName = signal('John');
+const lastName = signal('Doe');
+
+// Derived signal - automatically updates when dependencies change
+const fullName = computed(() => `${firstName()} ${lastName()}`);
+
+console.log(fullName()); // "John Doe"
+firstName.set('Jane');
+console.log(fullName()); // "Jane Doe"
+
+// Computed with complex logic
+const items = signal<Item[]>([]);
+const filter = signal('');
+
+const filteredItems = computed(() => {
+  const query = filter().toLowerCase();
+  return items().filter(item => 
+    item.name.toLowerCase().includes(query)
+  );
+});
+
+const totalPrice = computed(() => 
+  filteredItems().reduce((sum, item) => sum + item.price, 0)
+);
+```
+
+### Dependent State with Reset
+
+`linkedSignal()` does NOT exist in v18 (it arrives in v19). Get the same behavior with a writable selection signal plus a `computed()` fallback:
+
+```typescript
+import { signal, computed } from '@angular/core';
+
+const options = signal(['A', 'B', 'C']);
+const userSelected = signal<string | null>(null);
+
+// Falls back to first option whenever the user's choice is no longer valid
+const selected = computed(() => {
+  const choice = userSelected();
+  return choice !== null && options().includes(choice)
+    ? choice
+    : options()[0];
+});
+
+console.log(selected());   // "A"
+userSelected.set('B');     // User selects B
+console.log(selected());   // "B"
+options.set(['X', 'Y']);   // Options change, "B" no longer valid
+console.log(selected());   // "X" - falls back to first
+```
+
+### effect() - Side Effects
+
+```typescript
+import { signal, effect, inject, DestroyRef } from '@angular/core';
+
+@Component({...})
+export class Search {
+  query = signal('');
+  
+  constructor() {
+    // Effect runs when query changes
+    effect(() => {
+      console.log('Search query:', this.query());
+    });
+    
+    // Effect with cleanup
+    effect((onCleanup) => {
+      const timer = setInterval(() => {
+        console.log('Current query:', this.query());
+      }, 1000);
+      
+      onCleanup(() => clearInterval(timer));
+    });
+  }
+}
+```
+
+**Effect rules:**
+- Run in injection context (constructor or with `runInInjectionContext`)
+- Automatically cleaned up when component destroys
+- In v18, writing to a signal inside an effect throws unless you pass `{ allowSignalWrites: true }` as the effect's second argument (this restriction is removed in v19). Prefer `computed()` for derived state instead of writing signals from effects.
+
+```typescript
+// v18: signal writes inside effects need explicit opt-in
+effect(() => {
+  this.count.set(this.items().length); // avoid if a computed() can do it
+}, { allowSignalWrites: true });
+```
+
+## Component State Pattern
+
+```typescript
+@Component({
+  selector: 'app-todo-list',
+  template: `
+    <input [value]="newTodo()" (input)="newTodo.set($any($event.target).value)" />
+    <button (click)="addTodo()" [disabled]="!canAdd()">Add</button>
+    
+    <ul>
+      @for (todo of filteredTodos(); track todo.id) {
+        <li [class.done]="todo.done">
+          {{ todo.text }}
+          <button (click)="toggleTodo(todo.id)">Toggle</button>
+        </li>
+      }
+    </ul>
+    
+    <p>{{ remaining() }} remaining</p>
+  `,
+})
+export class TodoList {
+  // State
+  todos = signal<Todo[]>([]);
+  newTodo = signal('');
+  filter = signal<'all' | 'active' | 'done'>('all');
+  
+  // Derived state
+  canAdd = computed(() => this.newTodo().trim().length > 0);
+  
+  filteredTodos = computed(() => {
+    const todos = this.todos();
+    switch (this.filter()) {
+      case 'active': return todos.filter(t => !t.done);
+      case 'done': return todos.filter(t => t.done);
+      default: return todos;
+    }
+  });
+  
+  remaining = computed(() => 
+    this.todos().filter(t => !t.done).length
+  );
+  
+  // Actions
+  addTodo() {
+    const text = this.newTodo().trim();
+    if (text) {
+      this.todos.update(todos => [
+        ...todos,
+        { id: crypto.randomUUID(), text, done: false }
+      ]);
+      this.newTodo.set('');
+    }
+  }
+  
+  toggleTodo(id: string) {
+    this.todos.update(todos =>
+      todos.map(t => t.id === id ? { ...t, done: !t.done } : t)
+    );
+  }
+}
+```
+
+## RxJS Interop
+
+### toSignal() - Observable to Signal
+
+```typescript
+import { toSignal } from '@angular/core/rxjs-interop';
+import { interval } from 'rxjs';
+
+@Component({...})
+export class Timer {
+  private http = inject(HttpClient);
+  
+  // From observable - requires initial value or allowUndefined
+  counter = toSignal(interval(1000), { initialValue: 0 });
+  
+  // From HTTP - undefined until loaded
+  users = toSignal(this.http.get<User[]>('/api/users'));
+  
+  // With requireSync for synchronous observables (BehaviorSubject)
+  private user$ = new BehaviorSubject<User | null>(null);
+  currentUser = toSignal(this.user$, { requireSync: true });
+}
+```
+
+### toObservable() - Signal to Observable
+
+```typescript
+import { toObservable } from '@angular/core/rxjs-interop';
+import { switchMap, debounceTime } from 'rxjs';
+
+@Component({...})
+export class Search {
+  query = signal('');
+  
+  private http = inject(HttpClient);
+  
+  // Convert signal to observable for RxJS operators
+  results = toSignal(
+    toObservable(this.query).pipe(
+      debounceTime(300),
+      switchMap(q => this.http.get<Result[]>(`/api/search?q=${q}`))
+    ),
+    { initialValue: [] }
+  );
+}
+```
+
+## Signal Equality
+
+```typescript
+// Custom equality function
+const user = signal<User>(
+  { id: 1, name: 'Alice' },
+  { equal: (a, b) => a.id === b.id }
+);
+
+// Only triggers updates when ID changes
+user.set({ id: 1, name: 'Alice Updated' }); // No update
+user.set({ id: 2, name: 'Bob' }); // Triggers update
+```
+
+## Untracked Reads
+
+```typescript
+import { untracked } from '@angular/core';
+
+const a = signal(1);
+const b = signal(2);
+
+// Only depends on 'a', not 'b'
+const result = computed(() => {
+  const aVal = a();
+  const bVal = untracked(() => b());
+  return aVal + bVal;
+});
+```
+
+## Service State Pattern
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class Auth {
+  // Private writable state
+  private _user = signal<User | null>(null);
+  private _loading = signal(false);
+  
+  // Public read-only signals
+  readonly user = this._user.asReadonly();
+  readonly loading = this._loading.asReadonly();
+  readonly isAuthenticated = computed(() => this._user() !== null);
+  
+  private http = inject(HttpClient);
+  
+  async login(credentials: Credentials): Promise<void> {
+    this._loading.set(true);
+    try {
+      const user = await firstValueFrom(
+        this.http.post<User>('/api/login', credentials)
+      );
+      this._user.set(user);
+    } finally {
+      this._loading.set(false);
+    }
+  }
+  
+  logout(): void {
+    this._user.set(null);
+  }
+}
+```
+
+For advanced patterns, see [references/signal-patterns.md](references/signal-patterns.md).

--- a/.agents/skills/angular-signals/references/signal-patterns.md
+++ b/.agents/skills/angular-signals/references/signal-patterns.md
@@ -1,0 +1,323 @@
+# Angular Signal Patterns
+
+Note: the `resource()` API does not exist in Angular v18 (it arrives in v19). For async data with signals, use `toSignal()` over HttpClient observables — see [Async Operations](#async-operations).
+
+## Table of Contents
+- [Signal Store Pattern](#signal-store-pattern)
+- [Form State with Signals](#form-state-with-signals)
+- [Async Operations](#async-operations)
+- [Testing Signals](#testing-signals)
+
+## Signal Store Pattern
+
+For complex state, create a dedicated store:
+
+```typescript
+interface ProductState {
+  products: Product[];
+  selectedId: string | null;
+  filter: string;
+  loading: boolean;
+  error: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ProductSt {
+  // Private state
+  private state = signal<ProductState>({
+    products: [],
+    selectedId: null,
+    filter: '',
+    loading: false,
+    error: null,
+  });
+  
+  // Selectors (computed signals)
+  readonly products = computed(() => this.state().products);
+  readonly selectedId = computed(() => this.state().selectedId);
+  readonly filter = computed(() => this.state().filter);
+  readonly loading = computed(() => this.state().loading);
+  readonly error = computed(() => this.state().error);
+  
+  readonly filteredProducts = computed(() => {
+    const { products, filter } = this.state();
+    if (!filter) return products;
+    return products.filter(p => 
+      p.name.toLowerCase().includes(filter.toLowerCase())
+    );
+  });
+  
+  readonly selectedProduct = computed(() => {
+    const { products, selectedId } = this.state();
+    return products.find(p => p.id === selectedId) ?? null;
+  });
+  
+  private http = inject(HttpClient);
+  
+  // Actions
+  setFilter(filter: string): void {
+    this.state.update(s => ({ ...s, filter }));
+  }
+  
+  selectProduct(id: string | null): void {
+    this.state.update(s => ({ ...s, selectedId: id }));
+  }
+  
+  async loadProducts(): Promise<void> {
+    this.state.update(s => ({ ...s, loading: true, error: null }));
+    
+    try {
+      const products = await firstValueFrom(
+        this.http.get<Product[]>('/api/products')
+      );
+      this.state.update(s => ({ ...s, products, loading: false }));
+    } catch (err) {
+      this.state.update(s => ({ 
+        ...s, 
+        loading: false, 
+        error: 'Failed to load products' 
+      }));
+    }
+  }
+  
+  async addProduct(product: Omit<Product, 'id'>): Promise<void> {
+    const newProduct = await firstValueFrom(
+      this.http.post<Product>('/api/products', product)
+    );
+    this.state.update(s => ({
+      ...s,
+      products: [...s.products, newProduct],
+    }));
+  }
+}
+```
+
+## Form State with Signals
+
+```typescript
+interface FormState<T> {
+  value: T;
+  touched: boolean;
+  dirty: boolean;
+  valid: boolean;
+  errors: string[];
+}
+
+function createFormField<T>(
+  initialValue: T,
+  validators: ((value: T) => string | null)[] = []
+) {
+  const value = signal(initialValue);
+  const touched = signal(false);
+  const dirty = signal(false);
+  
+  const errors = computed(() => {
+    return validators
+      .map(v => v(value()))
+      .filter((e): e is string => e !== null);
+  });
+  
+  const valid = computed(() => errors().length === 0);
+  
+  return {
+    value,
+    touched: touched.asReadonly(),
+    dirty: dirty.asReadonly(),
+    errors,
+    valid,
+    
+    setValue(newValue: T) {
+      value.set(newValue);
+      dirty.set(true);
+    },
+    
+    markTouched() {
+      touched.set(true);
+    },
+    
+    reset() {
+      value.set(initialValue);
+      touched.set(false);
+      dirty.set(false);
+    },
+  };
+}
+
+// Usage
+@Component({...})
+export class Signup {
+  email = createFormField('', [
+    v => !v ? 'Email is required' : null,
+    v => !v.includes('@') ? 'Invalid email' : null,
+  ]);
+  
+  password = createFormField('', [
+    v => !v ? 'Password is required' : null,
+    v => v.length < 8 ? 'Password must be at least 8 characters' : null,
+  ]);
+  
+  formValid = computed(() => 
+    this.email.valid() && this.password.valid()
+  );
+}
+```
+
+## Async Operations
+
+### Debounced Search
+
+```typescript
+@Component({...})
+export class Search {
+  query = signal('');
+  
+  private http = inject(HttpClient);
+  
+  // Debounced search using toObservable
+  results = toSignal(
+    toObservable(this.query).pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      filter(q => q.length >= 2),
+      switchMap(q => this.http.get<Result[]>(`/api/search?q=${q}`)),
+      catchError(() => of([]))
+    ),
+    { initialValue: [] }
+  );
+  
+  // Loading state
+  private searching = signal(false);
+  readonly isSearching = this.searching.asReadonly();
+
+  constructor() {
+    // Track loading state (v18: signal writes in effects need allowSignalWrites)
+    effect(() => {
+      const q = this.query();
+      if (q.length >= 2) {
+        this.searching.set(true);
+      }
+    }, { allowSignalWrites: true });
+
+    effect(() => {
+      this.results(); // Subscribe to results
+      this.searching.set(false);
+    }, { allowSignalWrites: true });
+  }
+}
+```
+
+### Optimistic Updates
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class Todo {
+  private todos = signal<Todo[]>([]);
+  readonly items = this.todos.asReadonly();
+  
+  private http = inject(HttpClient);
+  
+  async toggleTodo(id: string): Promise<void> {
+    // Optimistic update
+    const previousTodos = this.todos();
+    this.todos.update(todos =>
+      todos.map(t => t.id === id ? { ...t, done: !t.done } : t)
+    );
+    
+    try {
+      await firstValueFrom(
+        this.http.patch(`/api/todos/${id}/toggle`, {})
+      );
+    } catch {
+      // Rollback on error
+      this.todos.set(previousTodos);
+    }
+  }
+}
+```
+
+## Testing Signals
+
+```typescript
+describe('Counter', () => {
+  it('should increment count', () => {
+    const component = new Counter();
+    
+    expect(component.count()).toBe(0);
+    
+    component.increment();
+    expect(component.count()).toBe(1);
+    
+    component.increment();
+    expect(component.count()).toBe(2);
+  });
+  
+  it('should compute doubled value', () => {
+    const component = new Counter();
+    
+    expect(component.doubled()).toBe(0);
+    
+    component.count.set(5);
+    expect(component.doubled()).toBe(10);
+  });
+});
+
+describe('ProductSt', () => {
+  let store: ProductSt;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ProductSt,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    store = TestBed.inject(ProductSt);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+  
+  it('should filter products', () => {
+    // Set initial state
+    store['state'].set({
+      products: [
+        { id: '1', name: 'Apple' },
+        { id: '2', name: 'Banana' },
+      ],
+      selectedId: null,
+      filter: '',
+      loading: false,
+      error: null,
+    });
+    
+    expect(store.filteredProducts().length).toBe(2);
+    
+    store.setFilter('app');
+    expect(store.filteredProducts().length).toBe(1);
+    expect(store.filteredProducts()[0].name).toBe('Apple');
+  });
+});
+```
+
+## Signal Debugging
+
+```typescript
+// Debug effect to log signal changes
+effect(() => {
+  console.log('State changed:', {
+    count: this.count(),
+    items: this.items(),
+    filter: this.filter(),
+  });
+});
+
+// Conditional debugging
+const DEBUG = signal(false);
+
+effect(() => {
+  if (untracked(() => DEBUG())) {
+    console.log('Debug:', this.state());
+  }
+});
+```

--- a/.agents/skills/deploy-to-vercel/SKILL.md
+++ b/.agents/skills/deploy-to-vercel/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: deploy-to-vercel
+description: Deploy applications and websites to Vercel. Use when the user requests deployment actions like "deploy my app", "deploy and give me the link", "push this live", or "create a preview deployment".
+metadata:
+  author: vercel
+  version: "3.0.0"
+---
+
+# Deploy to Vercel
+
+Deploy any project to Vercel. **Always deploy as preview** (not production) unless the user explicitly asks for production.
+
+The goal is to get the user into the best long-term setup: their project linked to Vercel with git-push deploys. Every method below tries to move the user closer to that state.
+
+## Step 1: Gather Project State
+
+Run all four checks before deciding which method to use:
+
+```bash
+# 1. Check for a git remote
+git remote get-url origin 2>/dev/null
+
+# 2. Check if locally linked to a Vercel project (either file means linked)
+cat .vercel/project.json 2>/dev/null || cat .vercel/repo.json 2>/dev/null
+
+# 3. Check if the Vercel CLI is installed and authenticated
+vercel whoami 2>/dev/null
+
+# 4. List available teams (if authenticated)
+vercel teams list --format json 2>/dev/null
+```
+
+### Team selection
+
+If the user belongs to multiple teams, present all available team slugs as a bulleted list and ask which one to deploy to. Once the user picks a team, proceed immediately to the next step — do not ask for additional confirmation.
+
+Pass the team slug via `--scope` on all subsequent CLI commands (`vercel deploy`, `vercel link`, `vercel inspect`, etc.):
+
+```bash
+vercel deploy [path] -y --no-wait --scope <team-slug>
+```
+
+If the project is already linked (`.vercel/project.json` or `.vercel/repo.json` exists), the `orgId` in those files determines the team — no need to ask again. If there is only one team (or just a personal account), skip the prompt and use it directly.
+
+**About the `.vercel/` directory:** A linked project has either:
+- `.vercel/project.json` — created by `vercel link` (single project linking). Contains `projectId` and `orgId`.
+- `.vercel/repo.json` — created by `vercel link --repo` (repo-based linking). Contains `orgId`, `remoteName`, and a `projects` array mapping directories to Vercel project IDs.
+
+Either file means the project is linked. Check for both.
+
+**Do NOT** use `vercel project inspect`, `vercel ls`, or `vercel link` to detect state in an unlinked directory — without a `.vercel/` config, they will interactively prompt (or with `--yes`, silently link as a side-effect). Only `vercel whoami` is safe to run anywhere.
+
+## Step 2: Choose a Deploy Method
+
+### Linked (`.vercel/` exists) + has git remote → Git Push
+
+This is the ideal state. The project is linked and has git integration.
+
+1. **Ask the user before pushing.** Never push without explicit approval:
+   ```
+   This project is connected to Vercel via git. I can commit and push to
+   trigger a deployment. Want me to proceed?
+   ```
+
+2. **Commit and push:**
+   ```bash
+   git add .
+   git commit -m "deploy: <description of changes>"
+   git push
+   ```
+   Vercel automatically builds from the push. Non-production branches get preview deployments; the production branch (usually `main`) gets a production deployment.
+
+3. **Retrieve the preview URL.** If the CLI is authenticated:
+   ```bash
+   sleep 5
+   vercel ls --format json
+   ```
+   The JSON output has a `deployments` array. Find the latest entry — its `url` field is the preview URL.
+
+   If the CLI is not authenticated, tell the user to check the Vercel dashboard or the commit status checks on their git provider for the preview URL.
+
+---
+
+### Linked (`.vercel/` exists) + no git remote → `vercel deploy`
+
+The project is linked but there's no git repo. Deploy directly with the CLI.
+
+```bash
+vercel deploy [path] -y --no-wait
+```
+
+Use `--no-wait` so the CLI returns immediately with the deployment URL instead of blocking until the build finishes (builds can take a while). Then check on the deployment status with:
+
+```bash
+vercel inspect <deployment-url>
+```
+
+For production deploys (only if user explicitly asks):
+```bash
+vercel deploy [path] --prod -y --no-wait
+```
+
+---
+
+### Not linked + CLI is authenticated → Link first, then deploy
+
+The CLI is working but the project isn't linked yet. This is the opportunity to get the user into the best state.
+
+1. **Ask the user which team to deploy to.** Present the team slugs from Step 1 as a bulleted list. If there's only one team (or just a personal account), skip this step.
+
+2. **Once a team is selected, proceed directly to linking.** Tell the user what will happen but do not ask for separate confirmation:
+   ```
+   Linking this project to <team name> on Vercel. This will create a Vercel
+   project to deploy to and enable automatic deployments on future git pushes.
+   ```
+
+3. **If a git remote exists**, use repo-based linking with the selected team scope:
+   ```bash
+   vercel link --repo --scope <team-slug>
+   ```
+   This reads the git remote URL and matches it to existing Vercel projects that deploy from that repo. It creates `.vercel/repo.json`. This is much more reliable than `vercel link` (without `--repo`), which tries to match by directory name and often fails when the local folder and Vercel project are named differently.
+
+   **If there is no git remote**, fall back to standard linking:
+   ```bash
+   vercel link --scope <team-slug>
+   ```
+   This prompts the user to select or create a project. It creates `.vercel/project.json`.
+
+4. **Then deploy using the best available method:**
+   - If a git remote exists → commit and push (see git push method above)
+   - If no git remote → `vercel deploy [path] -y --no-wait --scope <team-slug>`, then `vercel inspect <url>` to check status
+
+---
+
+### Not linked + CLI not authenticated → Install, auth, link, deploy
+
+The Vercel CLI isn't set up at all.
+
+1. **Install the CLI (if not already installed):**
+   ```bash
+   npm install -g vercel
+   ```
+
+2. **Authenticate:**
+   ```bash
+   vercel login
+   ```
+   The user completes auth in their browser. If running in a non-interactive environment where login is not possible, skip to the **no-auth fallback** below.
+
+3. **Ask which team to deploy to** — present team slugs from `vercel teams list --format json` as a bulleted list. If only one team / personal account, skip. Once selected, proceed immediately.
+
+4. **Link the project** with the selected team scope (use `--repo` if a git remote exists, plain `vercel link` otherwise):
+   ```bash
+   vercel link --repo --scope <team-slug>   # if git remote exists
+   vercel link --scope <team-slug>          # if no git remote
+   ```
+
+5. **Deploy** using the best available method (git push if remote exists, otherwise `vercel deploy -y --no-wait --scope <team-slug>`, then `vercel inspect <url>` to check status).
+
+---
+
+### No-Auth Fallback — claude.ai sandbox
+
+**When to use:** Last resort when the CLI can't be installed or authenticated in the claude.ai sandbox. This requires no authentication — it returns a **Preview URL** (live site) and a **Claim URL** (transfer to your Vercel account).
+
+```bash
+bash /mnt/skills/user/deploy-to-vercel/resources/deploy.sh [path]
+```
+
+**Arguments:**
+- `path` - Directory to deploy, or a `.tgz` file (defaults to current directory)
+
+**Examples:**
+```bash
+# Deploy current directory
+bash /mnt/skills/user/deploy-to-vercel/resources/deploy.sh
+
+# Deploy specific project
+bash /mnt/skills/user/deploy-to-vercel/resources/deploy.sh /path/to/project
+
+# Deploy existing tarball
+bash /mnt/skills/user/deploy-to-vercel/resources/deploy.sh /path/to/project.tgz
+```
+
+The script auto-detects the framework from `package.json`, packages the project (excluding `node_modules`, `.git`, `.env`), uploads it, and waits for the build to complete.
+
+**Tell the user:** "Your deployment is ready at [previewUrl]. Claim it at [claimUrl] to manage your deployment."
+
+---
+
+### No-Auth Fallback — Codex sandbox
+
+**When to use:** In the Codex sandbox where the CLI may not be authenticated. Codex runs in a sandboxed environment by default — try the CLI first, and fall back to the deploy script if auth fails.
+
+1. **Check whether the Vercel CLI is installed** (no escalation needed for this check):
+   ```bash
+   command -v vercel
+   ```
+
+2. **If `vercel` is installed**, try deploying with the CLI:
+   ```bash
+   vercel deploy [path] -y --no-wait
+   ```
+
+3. **If `vercel` is not installed, or the CLI fails with "No existing credentials found"**, use the fallback script:
+   ```bash
+   skill_dir="<path-to-skill>"
+
+   # Deploy current directory
+   bash "$skill_dir/resources/deploy-codex.sh"
+
+   # Deploy specific project
+   bash "$skill_dir/resources/deploy-codex.sh" /path/to/project
+
+   # Deploy existing tarball
+   bash "$skill_dir/resources/deploy-codex.sh" /path/to/project.tgz
+   ```
+
+The script handles framework detection, packaging, and deployment. It waits for the build to complete and returns JSON with `previewUrl` and `claimUrl`.
+
+**Tell the user:** "Your deployment is ready at [previewUrl]. Claim it at [claimUrl] to manage your deployment."
+
+**Escalated network access:** Only escalate the actual deploy command if sandboxing blocks the network call (`sandbox_permissions=require_escalated`). Do **not** escalate the `command -v vercel` check.
+
+---
+
+## Agent-Specific Notes
+
+### Claude Code / terminal-based agents
+
+You have full shell access. Do NOT use the `/mnt/skills/` path. Follow the decision flow above using the CLI directly.
+
+For the no-auth fallback, run the deploy script from the skill's installed location:
+```bash
+bash ~/.claude/skills/deploy-to-vercel/resources/deploy.sh [path]
+```
+The path may vary depending on where the user installed the skill.
+
+### Sandboxed environments (claude.ai)
+
+You likely cannot run `vercel login` or `git push`. Go directly to the **no-auth fallback — claude.ai sandbox**.
+
+### Codex
+
+Codex runs in a sandbox. Check if the CLI is available first, then fall back to the deploy script. Go to the **no-auth fallback — Codex sandbox**.
+
+---
+
+## Output
+
+Always show the user the deployment URL.
+
+- **Git push:** Use `vercel ls --format json` to find the preview URL. If the CLI isn't authenticated, tell the user to check the Vercel dashboard or commit status checks.
+- **CLI deploy:** Show the URL returned by `vercel deploy --no-wait`. Use `vercel inspect <url>` to check build status and report it to the user.
+- **No-auth fallback:** Show both the preview URL and the claim URL:
+  ```
+  Deployment successful!
+
+  Preview URL: https://my-app-abc123.vercel.app
+  Claim URL:   https://vercel.com/claim-deployment?code=...
+
+  View your site at the Preview URL.
+  To transfer this deployment to your Vercel account, visit the Claim URL.
+  ```
+
+**Do not** curl or fetch the deployed URL to verify it works. Just return the link.
+
+---
+
+## Troubleshooting
+
+### Network Egress Error (claude.ai)
+
+If deployment fails due to network restrictions on claude.ai, tell the user:
+
+```
+Deployment failed due to network restrictions. To fix this:
+
+1. Go to https://claude.ai/settings/capabilities
+2. Add *.vercel.com to the allowed domains
+3. Try deploying again
+```
+
+### Escalated Network Access (Codex / sandboxed environments)
+
+If deployment fails due to network issues (timeouts, DNS errors, connection resets) in a sandboxed environment, rerun with escalated permissions (`sandbox_permissions=require_escalated`). Do not escalate the initial CLI availability check — only escalate the actual deploy command.
+
+Example guidance to the user:
+```
+The deploy needs escalated network access to deploy to Vercel. I can rerun
+the command with escalated permissions — want me to proceed?
+```
+
+### CLI Auth Failure
+
+If `vercel login` or `vercel deploy` fails with authentication errors, fall back to the no-auth deploy script (claude.ai or Codex variant, depending on the environment).

--- a/.agents/skills/deploy-to-vercel/resources/deploy-codex.sh
+++ b/.agents/skills/deploy-to-vercel/resources/deploy-codex.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+
+# Vercel Deployment Script for Codex (via claimable deploy endpoint)
+# Usage: ./deploy-codex.sh [project-path]
+# Returns: JSON with previewUrl, claimUrl, deploymentId, projectId
+
+set -euo pipefail
+
+DEPLOY_ENDPOINT="https://codex-deploy-skills.vercel.sh/api/deploy"
+
+# Detect framework from package.json
+detect_framework() {
+    local pkg_json="$1"
+
+    if [ ! -f "$pkg_json" ]; then
+        echo "null"
+        return
+    fi
+
+    local content=$(cat "$pkg_json")
+
+    # Helper to check if a package exists in dependencies or devDependencies.
+    # Use exact matching by default, with a separate prefix matcher for scoped
+    # package families like "@remix-run/".
+    has_dep_exact() {
+        echo "$content" | grep -q "\"$1\""
+    }
+
+    has_dep_prefix() {
+        echo "$content" | grep -q "\"$1"
+    }
+
+    # Order matters - check more specific frameworks first
+
+    # Blitz
+    if has_dep_exact "blitz"; then echo "blitzjs"; return; fi
+
+    # Next.js
+    if has_dep_exact "next"; then echo "nextjs"; return; fi
+
+    # Gatsby
+    if has_dep_exact "gatsby"; then echo "gatsby"; return; fi
+
+    # Remix
+    if has_dep_prefix "@remix-run/"; then echo "remix"; return; fi
+
+    # React Router (v7 framework mode)
+    if has_dep_prefix "@react-router/"; then echo "react-router"; return; fi
+
+    # TanStack Start
+    if has_dep_exact "@tanstack/start"; then echo "tanstack-start"; return; fi
+
+    # Astro
+    if has_dep_exact "astro"; then echo "astro"; return; fi
+
+    # Hydrogen (Shopify)
+    if has_dep_exact "@shopify/hydrogen"; then echo "hydrogen"; return; fi
+
+    # SvelteKit
+    if has_dep_exact "@sveltejs/kit"; then echo "sveltekit-1"; return; fi
+
+    # Svelte (standalone)
+    if has_dep_exact "svelte"; then echo "svelte"; return; fi
+
+    # Nuxt
+    if has_dep_exact "nuxt"; then echo "nuxtjs"; return; fi
+
+    # Vue with Vitepress
+    if has_dep_exact "vitepress"; then echo "vitepress"; return; fi
+
+    # Vue with Vuepress
+    if has_dep_exact "vuepress"; then echo "vuepress"; return; fi
+
+    # Gridsome
+    if has_dep_exact "gridsome"; then echo "gridsome"; return; fi
+
+    # SolidStart
+    if has_dep_exact "@solidjs/start"; then echo "solidstart-1"; return; fi
+
+    # Docusaurus
+    if has_dep_exact "@docusaurus/core"; then echo "docusaurus-2"; return; fi
+
+    # RedwoodJS
+    if has_dep_prefix "@redwoodjs/"; then echo "redwoodjs"; return; fi
+
+    # Hexo
+    if has_dep_exact "hexo"; then echo "hexo"; return; fi
+
+    # Eleventy
+    if has_dep_exact "@11ty/eleventy"; then echo "eleventy"; return; fi
+
+    # Angular / Ionic Angular
+    if has_dep_exact "@ionic/angular"; then echo "ionic-angular"; return; fi
+    if has_dep_exact "@angular/core"; then echo "angular"; return; fi
+
+    # Ionic React
+    if has_dep_exact "@ionic/react"; then echo "ionic-react"; return; fi
+
+    # Create React App
+    if has_dep_exact "react-scripts"; then echo "create-react-app"; return; fi
+
+    # Ember
+    if has_dep_exact "ember-cli" || has_dep_exact "ember-source"; then echo "ember"; return; fi
+
+    # Dojo
+    if has_dep_exact "@dojo/framework"; then echo "dojo"; return; fi
+
+    # Polymer
+    if has_dep_prefix "@polymer/"; then echo "polymer"; return; fi
+
+    # Preact
+    if has_dep_exact "preact"; then echo "preact"; return; fi
+
+    # Stencil
+    if has_dep_exact "@stencil/core"; then echo "stencil"; return; fi
+
+    # UmiJS
+    if has_dep_exact "umi"; then echo "umijs"; return; fi
+
+    # Sapper (legacy Svelte)
+    if has_dep_exact "sapper"; then echo "sapper"; return; fi
+
+    # Saber
+    if has_dep_exact "saber"; then echo "saber"; return; fi
+
+    # Sanity
+    if has_dep_exact "sanity"; then echo "sanity-v3"; return; fi
+    if has_dep_prefix "@sanity/"; then echo "sanity"; return; fi
+
+    # Storybook
+    if has_dep_prefix "@storybook/"; then echo "storybook"; return; fi
+
+    # NestJS
+    if has_dep_exact "@nestjs/core"; then echo "nestjs"; return; fi
+
+    # Elysia
+    if has_dep_exact "elysia"; then echo "elysia"; return; fi
+
+    # Hono
+    if has_dep_exact "hono"; then echo "hono"; return; fi
+
+    # Fastify
+    if has_dep_exact "fastify"; then echo "fastify"; return; fi
+
+    # h3
+    if has_dep_exact "h3"; then echo "h3"; return; fi
+
+    # Nitro
+    if has_dep_exact "nitropack"; then echo "nitro"; return; fi
+
+    # Express
+    if has_dep_exact "express"; then echo "express"; return; fi
+
+    # Vite (generic - check last among JS frameworks)
+    if has_dep_exact "vite"; then echo "vite"; return; fi
+
+    # Parcel
+    if has_dep_exact "parcel"; then echo "parcel"; return; fi
+
+    # No framework detected
+    echo "null"
+}
+
+# Parse arguments
+INPUT_PATH="${1:-.}"
+
+# Create temp directory for packaging
+TEMP_DIR=$(mktemp -d)
+TARBALL="$TEMP_DIR/project.tgz"
+STAGING_DIR="$TEMP_DIR/staging"
+CLEANUP_TEMP=true
+
+cleanup() {
+    if [ "$CLEANUP_TEMP" = true ]; then
+        rm -rf "$TEMP_DIR"
+    fi
+}
+trap cleanup EXIT
+
+echo "Preparing deployment..." >&2
+
+# Check if input is a .tgz file or a directory
+FRAMEWORK="null"
+
+if [ -f "$INPUT_PATH" ] && [[ "$INPUT_PATH" == *.tgz ]]; then
+    # Input is already a tarball, use it directly
+    echo "Using provided tarball..." >&2
+    TARBALL="$INPUT_PATH"
+    CLEANUP_TEMP=false
+    # Can't detect framework from tarball, leave as null
+elif [ -d "$INPUT_PATH" ]; then
+    # Input is a directory, need to tar it
+    PROJECT_PATH=$(cd "$INPUT_PATH" && pwd)
+
+    # Detect framework from package.json
+    FRAMEWORK=$(detect_framework "$PROJECT_PATH/package.json")
+
+    # Stage files into a temporary directory to avoid mutating the source tree.
+    mkdir -p "$STAGING_DIR"
+    echo "Staging project files..." >&2
+    tar -C "$PROJECT_PATH" \
+        --exclude='node_modules' \
+        --exclude='.git' \
+        --exclude='.env' \
+        --exclude='.env.*' \
+        -cf - . | tar -C "$STAGING_DIR" -xf -
+
+    # Check if this is a static HTML project (no package.json)
+    if [ ! -f "$PROJECT_PATH/package.json" ]; then
+        # Find HTML files in root
+        HTML_FILES=$(find "$STAGING_DIR" -maxdepth 1 -name "*.html" -type f)
+        HTML_COUNT=$(printf '%s\n' "$HTML_FILES" | sed '/^$/d' | wc -l | tr -d '[:space:]')
+
+        # If there's exactly one HTML file and it's not index.html, rename it
+        if [ "$HTML_COUNT" -eq 1 ]; then
+            HTML_FILE=$(echo "$HTML_FILES" | head -1)
+            BASENAME=$(basename "$HTML_FILE")
+            if [ "$BASENAME" != "index.html" ]; then
+                echo "Renaming $BASENAME to index.html..." >&2
+                mv "$HTML_FILE" "$STAGING_DIR/index.html"
+            fi
+        fi
+    fi
+
+    # Create tarball from the staging directory
+    echo "Creating deployment package..." >&2
+    tar -czf "$TARBALL" -C "$STAGING_DIR" .
+else
+    echo "Error: Input must be a directory or a .tgz file" >&2
+    exit 1
+fi
+
+if [ "$FRAMEWORK" != "null" ]; then
+    echo "Detected framework: $FRAMEWORK" >&2
+fi
+
+# Deploy
+echo "Deploying..." >&2
+RESPONSE=$(curl -s -X POST "$DEPLOY_ENDPOINT" -F "file=@$TARBALL" -F "framework=$FRAMEWORK")
+
+# Check for error in response
+if echo "$RESPONSE" | grep -q '"error"'; then
+    ERROR_MSG=$(echo "$RESPONSE" | grep -o '"error":"[^"]*"' | cut -d'"' -f4)
+    echo "Error: $ERROR_MSG" >&2
+    exit 1
+fi
+
+# Extract URLs from response
+PREVIEW_URL=$(echo "$RESPONSE" | grep -o '"previewUrl":"[^"]*"' | cut -d'"' -f4)
+CLAIM_URL=$(echo "$RESPONSE" | grep -o '"claimUrl":"[^"]*"' | cut -d'"' -f4)
+
+if [ -z "$PREVIEW_URL" ]; then
+    echo "Error: Could not extract preview URL from response" >&2
+    echo "$RESPONSE" >&2
+    exit 1
+fi
+
+echo "Deployment started. Waiting for build to complete..." >&2
+echo "Preview URL: $PREVIEW_URL" >&2
+
+# Poll the preview URL until it returns a non-5xx response (5xx = still building)
+MAX_ATTEMPTS=60  # 5 minutes max (60 * 5 seconds)
+ATTEMPT=0
+
+while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$PREVIEW_URL")
+
+    if [ "$HTTP_STATUS" -eq 200 ]; then
+        echo "" >&2
+        echo "Deployment ready!" >&2
+        break
+    elif [ "$HTTP_STATUS" -ge 500 ]; then
+        # 5xx means still building/deploying
+        echo "Building... (attempt $((ATTEMPT + 1))/$MAX_ATTEMPTS)" >&2
+        sleep 5
+        ATTEMPT=$((ATTEMPT + 1))
+    elif [ "$HTTP_STATUS" -ge 400 ] && [ "$HTTP_STATUS" -lt 500 ]; then
+        # 4xx might be an error or the app itself returns 4xx - it's responding
+        echo "" >&2
+        echo "Deployment ready (returned $HTTP_STATUS)!" >&2
+        break
+    else
+        # Any other status, assume it's ready
+        echo "" >&2
+        echo "Deployment ready!" >&2
+        break
+    fi
+done
+
+if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+    echo "" >&2
+    echo "Warning: Timed out waiting for deployment, but it may still be building." >&2
+fi
+
+echo "" >&2
+echo "Preview URL: $PREVIEW_URL" >&2
+echo "Claim URL:   $CLAIM_URL" >&2
+echo "" >&2
+
+# Output JSON for programmatic use
+echo "$RESPONSE"

--- a/.agents/skills/deploy-to-vercel/resources/deploy.sh
+++ b/.agents/skills/deploy-to-vercel/resources/deploy.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+
+# Vercel Deployment Script (via claimable deploy endpoint)
+# Usage: ./deploy.sh [project-path]
+# Returns: JSON with previewUrl, claimUrl, deploymentId, projectId
+
+set -euo pipefail
+
+DEPLOY_ENDPOINT="https://claude-skills-deploy.vercel.com/api/deploy"
+
+# Detect framework from package.json
+detect_framework() {
+    local pkg_json="$1"
+
+    if [ ! -f "$pkg_json" ]; then
+        echo "null"
+        return
+    fi
+
+    local content=$(cat "$pkg_json")
+
+    # Helper to check if a package exists in dependencies or devDependencies.
+    # Use exact matching by default, with a separate prefix matcher for scoped
+    # package families like "@remix-run/".
+    has_dep_exact() {
+        echo "$content" | grep -q "\"$1\""
+    }
+
+    has_dep_prefix() {
+        echo "$content" | grep -q "\"$1"
+    }
+
+    # Order matters - check more specific frameworks first
+
+    # Blitz
+    if has_dep_exact "blitz"; then echo "blitzjs"; return; fi
+
+    # Next.js
+    if has_dep_exact "next"; then echo "nextjs"; return; fi
+
+    # Gatsby
+    if has_dep_exact "gatsby"; then echo "gatsby"; return; fi
+
+    # Remix
+    if has_dep_prefix "@remix-run/"; then echo "remix"; return; fi
+
+    # React Router (v7 framework mode)
+    if has_dep_prefix "@react-router/"; then echo "react-router"; return; fi
+
+    # TanStack Start
+    if has_dep_exact "@tanstack/start"; then echo "tanstack-start"; return; fi
+
+    # Astro
+    if has_dep_exact "astro"; then echo "astro"; return; fi
+
+    # Hydrogen (Shopify)
+    if has_dep_exact "@shopify/hydrogen"; then echo "hydrogen"; return; fi
+
+    # SvelteKit
+    if has_dep_exact "@sveltejs/kit"; then echo "sveltekit-1"; return; fi
+
+    # Svelte (standalone)
+    if has_dep_exact "svelte"; then echo "svelte"; return; fi
+
+    # Nuxt
+    if has_dep_exact "nuxt"; then echo "nuxtjs"; return; fi
+
+    # Vue with Vitepress
+    if has_dep_exact "vitepress"; then echo "vitepress"; return; fi
+
+    # Vue with Vuepress
+    if has_dep_exact "vuepress"; then echo "vuepress"; return; fi
+
+    # Gridsome
+    if has_dep_exact "gridsome"; then echo "gridsome"; return; fi
+
+    # SolidStart
+    if has_dep_exact "@solidjs/start"; then echo "solidstart-1"; return; fi
+
+    # Docusaurus
+    if has_dep_exact "@docusaurus/core"; then echo "docusaurus-2"; return; fi
+
+    # RedwoodJS
+    if has_dep_prefix "@redwoodjs/"; then echo "redwoodjs"; return; fi
+
+    # Hexo
+    if has_dep_exact "hexo"; then echo "hexo"; return; fi
+
+    # Eleventy
+    if has_dep_exact "@11ty/eleventy"; then echo "eleventy"; return; fi
+
+    # Angular / Ionic Angular
+    if has_dep_exact "@ionic/angular"; then echo "ionic-angular"; return; fi
+    if has_dep_exact "@angular/core"; then echo "angular"; return; fi
+
+    # Ionic React
+    if has_dep_exact "@ionic/react"; then echo "ionic-react"; return; fi
+
+    # Create React App
+    if has_dep_exact "react-scripts"; then echo "create-react-app"; return; fi
+
+    # Ember
+    if has_dep_exact "ember-cli" || has_dep_exact "ember-source"; then echo "ember"; return; fi
+
+    # Dojo
+    if has_dep_exact "@dojo/framework"; then echo "dojo"; return; fi
+
+    # Polymer
+    if has_dep_prefix "@polymer/"; then echo "polymer"; return; fi
+
+    # Preact
+    if has_dep_exact "preact"; then echo "preact"; return; fi
+
+    # Stencil
+    if has_dep_exact "@stencil/core"; then echo "stencil"; return; fi
+
+    # UmiJS
+    if has_dep_exact "umi"; then echo "umijs"; return; fi
+
+    # Sapper (legacy Svelte)
+    if has_dep_exact "sapper"; then echo "sapper"; return; fi
+
+    # Saber
+    if has_dep_exact "saber"; then echo "saber"; return; fi
+
+    # Sanity
+    if has_dep_exact "sanity"; then echo "sanity-v3"; return; fi
+    if has_dep_prefix "@sanity/"; then echo "sanity"; return; fi
+
+    # Storybook
+    if has_dep_prefix "@storybook/"; then echo "storybook"; return; fi
+
+    # NestJS
+    if has_dep_exact "@nestjs/core"; then echo "nestjs"; return; fi
+
+    # Elysia
+    if has_dep_exact "elysia"; then echo "elysia"; return; fi
+
+    # Hono
+    if has_dep_exact "hono"; then echo "hono"; return; fi
+
+    # Fastify
+    if has_dep_exact "fastify"; then echo "fastify"; return; fi
+
+    # h3
+    if has_dep_exact "h3"; then echo "h3"; return; fi
+
+    # Nitro
+    if has_dep_exact "nitropack"; then echo "nitro"; return; fi
+
+    # Express
+    if has_dep_exact "express"; then echo "express"; return; fi
+
+    # Vite (generic - check last among JS frameworks)
+    if has_dep_exact "vite"; then echo "vite"; return; fi
+
+    # Parcel
+    if has_dep_exact "parcel"; then echo "parcel"; return; fi
+
+    # No framework detected
+    echo "null"
+}
+
+# Parse arguments
+INPUT_PATH="${1:-.}"
+
+# Create temp directory for packaging
+TEMP_DIR=$(mktemp -d)
+TARBALL="$TEMP_DIR/project.tgz"
+STAGING_DIR="$TEMP_DIR/staging"
+CLEANUP_TEMP=true
+
+cleanup() {
+    if [ "$CLEANUP_TEMP" = true ]; then
+        rm -rf "$TEMP_DIR"
+    fi
+}
+trap cleanup EXIT
+
+echo "Preparing deployment..." >&2
+
+# Check if input is a .tgz file or a directory
+FRAMEWORK="null"
+
+if [ -f "$INPUT_PATH" ] && [[ "$INPUT_PATH" == *.tgz ]]; then
+    # Input is already a tarball, use it directly
+    echo "Using provided tarball..." >&2
+    TARBALL="$INPUT_PATH"
+    CLEANUP_TEMP=false
+    # Can't detect framework from tarball, leave as null
+elif [ -d "$INPUT_PATH" ]; then
+    # Input is a directory, need to tar it
+    PROJECT_PATH=$(cd "$INPUT_PATH" && pwd)
+
+    # Detect framework from package.json
+    FRAMEWORK=$(detect_framework "$PROJECT_PATH/package.json")
+
+    # Stage files into a temporary directory to avoid mutating the source tree.
+    mkdir -p "$STAGING_DIR"
+    echo "Staging project files..." >&2
+    tar -C "$PROJECT_PATH" \
+        --exclude='node_modules' \
+        --exclude='.git' \
+        --exclude='.env' \
+        --exclude='.env.*' \
+        -cf - . | tar -C "$STAGING_DIR" -xf -
+
+    # Check if this is a static HTML project (no package.json)
+    if [ ! -f "$PROJECT_PATH/package.json" ]; then
+        # Find HTML files in root
+        HTML_FILES=$(find "$STAGING_DIR" -maxdepth 1 -name "*.html" -type f)
+        HTML_COUNT=$(printf '%s\n' "$HTML_FILES" | sed '/^$/d' | wc -l | tr -d '[:space:]')
+
+        # If there's exactly one HTML file and it's not index.html, rename it
+        if [ "$HTML_COUNT" -eq 1 ]; then
+            HTML_FILE=$(echo "$HTML_FILES" | head -1)
+            BASENAME=$(basename "$HTML_FILE")
+            if [ "$BASENAME" != "index.html" ]; then
+                echo "Renaming $BASENAME to index.html..." >&2
+                mv "$HTML_FILE" "$STAGING_DIR/index.html"
+            fi
+        fi
+    fi
+
+    # Create tarball from the staging directory
+    echo "Creating deployment package..." >&2
+    tar -czf "$TARBALL" -C "$STAGING_DIR" .
+else
+    echo "Error: Input must be a directory or a .tgz file" >&2
+    exit 1
+fi
+
+if [ "$FRAMEWORK" != "null" ]; then
+    echo "Detected framework: $FRAMEWORK" >&2
+fi
+
+# Deploy
+echo "Deploying..." >&2
+RESPONSE=$(curl -s -X POST "$DEPLOY_ENDPOINT" -F "file=@$TARBALL" -F "framework=$FRAMEWORK")
+
+# Check for error in response
+if echo "$RESPONSE" | grep -q '"error"'; then
+    ERROR_MSG=$(echo "$RESPONSE" | grep -o '"error":"[^"]*"' | cut -d'"' -f4)
+    echo "Error: $ERROR_MSG" >&2
+    exit 1
+fi
+
+# Extract URLs from response
+PREVIEW_URL=$(echo "$RESPONSE" | grep -o '"previewUrl":"[^"]*"' | cut -d'"' -f4)
+CLAIM_URL=$(echo "$RESPONSE" | grep -o '"claimUrl":"[^"]*"' | cut -d'"' -f4)
+
+if [ -z "$PREVIEW_URL" ]; then
+    echo "Error: Could not extract preview URL from response" >&2
+    echo "$RESPONSE" >&2
+    exit 1
+fi
+
+echo "Deployment started. Waiting for build to complete..." >&2
+echo "Preview URL: $PREVIEW_URL" >&2
+
+# Poll the preview URL until it returns a non-5xx response (5xx = still building)
+MAX_ATTEMPTS=60  # 5 minutes max (60 * 5 seconds)
+ATTEMPT=0
+
+while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$PREVIEW_URL")
+
+    if [ "$HTTP_STATUS" -eq 200 ]; then
+        echo "" >&2
+        echo "Deployment ready!" >&2
+        break
+    elif [ "$HTTP_STATUS" -ge 500 ]; then
+        # 5xx means still building/deploying
+        echo "Building... (attempt $((ATTEMPT + 1))/$MAX_ATTEMPTS)" >&2
+        sleep 5
+        ATTEMPT=$((ATTEMPT + 1))
+    elif [ "$HTTP_STATUS" -ge 400 ] && [ "$HTTP_STATUS" -lt 500 ]; then
+        # 4xx might be an error or the app itself returns 4xx - it's responding
+        echo "" >&2
+        echo "Deployment ready (returned $HTTP_STATUS)!" >&2
+        break
+    else
+        # Any other status, assume it's ready
+        echo "" >&2
+        echo "Deployment ready!" >&2
+        break
+    fi
+done
+
+if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+    echo "" >&2
+    echo "Warning: Timed out waiting for deployment, but it may still be building." >&2
+fi
+
+echo "" >&2
+echo "Preview URL: $PREVIEW_URL" >&2
+echo "Claim URL:   $CLAIM_URL" >&2
+echo "" >&2
+
+# Output JSON for programmatic use
+echo "$RESPONSE"

--- a/.agents/skills/mongodb-query-optimizer/SKILL.md
+++ b/.agents/skills/mongodb-query-optimizer/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: mongodb-query-optimizer
+description: >-
+  Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: "How do I optimize this query?", "How do I index this?", "Why is this query slow?", "Can you fix my slow queries?", "What are the slow queries on my cluster?", etc. Do not invoke for general MongoDB query writing unless user asks for performance or index help. Prefer indexing as optimization strategy. Use MongoDB MCP when available.
+compatibility: >-
+  Best with MongoDB MCP server. Uses collection-indexes and explain when the connection string works; uses Atlas Performance Advisor when Atlas API is configured. Without either, suggest indexes from query shape only. User creates indexes in Atlas or migrations unless tooling allows otherwise.
+license: Apache-2.0
+metadata:
+  version: "1.0.0"
+---
+
+# MongoDB Query Optimizer
+
+## When this skill is invoked
+
+Invoke **only** when the user wants:
+
+- Query/index **optimization** or **performance** help  
+- **Why** a query is slow or **how to speed it up**  
+- **Slow queries** on their cluster and/or **how to optimize them**
+
+Do **not** invoke for routine query authoring unless the user has requested help with optimization, slow queries, or indexing.
+
+## High Level Workflow
+
+### General Performance Help
+
+If the user wants to examine slow queries, or is looking for general performance suggestions (not regarding any particular query):
+
+- Use MongoDB MCP server **atlas-get-performance-advisor** tool to fetch slow query logs and performance advisor output  
+- Make suggestions based on this information
+
+If Atlas MCP Server for Atlas is not configured or you don’t have enough information to run **atlas-get-performance-advisor** against the correct cluster, tell the user that general performance analysis requires Atlas MCP Server configuration with API credentials, and suggest they configure it or ask about a specific query instead.
+
+### Help with a Specific Query
+
+If the user is asking about a particular query:
+
+- Use **collection-indexes**, **explain**, and **find** MCP tools to get existing indexes on the collection, explain() output for the query, and a sample document from the collection  
+- Use **atlas-get-performance-advisor MCP** tool to fetch slow query logs and performance advisor output
+
+Then make an optimization suggestion based on collected information and MongoDB best practices and examples from reference files. Prefer creating an index that fully covers the query if possible. If you cannot use MongoDB MCP Server then still try to make a suggestion.
+
+## MCP: available tools
+
+**How to invoke.** Call the **MongoDB MCP server** with the **exact tool name** as `toolName` and a single **arguments object** as `arguments`. Do not pass the tool name as an option, query param, or nested key; pass it as the MCP tool name and the parameters as the arguments object. Full MCP Server tool reference: [MongoDB MCP Server Tools](https://www.mongodb.com/docs/mcp-server/tools/).
+
+**Database tools** (when the MCP cluster connection works):
+
+| Tool name (exact) | Arguments object |
+| :---- | :---- |
+| `collection-indexes` | `{ "database": "<db>", "collection": "<coll>" }` — both required strings. |
+| `explain` | `{ "database": "<db>", "collection": "<coll>", "method": [ { "name": "find", "arguments": { "filter": {...}, "sort": {...}, "limit": N } } ], "verbosity": "executionStats" }`. `method` is an array of one object: `name` is `"find"`, `"aggregate"`, or `"count"`; `arguments` holds that method's params (e.g. find: `filter`, `sort`, `limit`; aggregate: `pipeline`; count: `query`). Optional `verbosity`: `"queryPlanner"` (default), `"executionStats"`, `"queryPlannerExtended"`, `"allPlansExecution"`. |
+| `find` |  `{ "database": "<db>", "collection": "<coll>", "filter": {...}, "projection": {...}, "sort": {...}, "limit": N }` — `database`, `collection`, and `filter` are required. Optional: `projection`, `sort`, `limit`. |
+
+**Atlas tools** (when Atlas API credentials are configured):
+
+| Tool name (exact) | Arguments object |
+| :---- | :---- |
+| `atlas-list-projects` | `{}` or `{ "orgId": "<24-char hex>" }`. Returns projects with their IDs; use to get `projectId` for Performance Advisor. |
+| `atlas-get-performance-advisor` | **Required:** `"projectId"` (24-character hex string), `"clusterName"` (string, 1–64 chars, alphanumeric/underscore/dash). **Optional:** `"operations"` — array of strings from `"suggestedIndexes"`, `"dropIndexSuggestions"`, `"slowQueryLogs"`, `"schemaSuggestions"` (request only what you need); for slowQueryLogs only: `"since"` (ISO 8601 date-time), `"namespaces"` (array of `"db.coll"` strings). |
+
+For a user question, try to fetch information from both the connection string and Atlas API related to the query you are optimizing.
+
+### 1\. DB connection string works for MongoDB MCP
+
+Typical flow: call `collection-indexes` → `explain` → `find` (sample doc).
+
+- **`collection-indexes`** — Use the result's `classicIndexes` (each has `name`, `key`) to see if the query can already use an existing index.
+- **`explain`** — Run in `"queryPlanner"` mode first to check for COLLSCAN. If the query uses an index or the collection is very small, run again with `"executionStats"` (10-second timeout) to get docs scanned vs. returned.
+
+### 2\. Atlas API access works for MongoDB MCP
+
+If you need a project ID, call `atlas-list-projects` first. Then call `atlas-get-performance-advisor` with only the `operations` you need:
+
+| Operation value | Use when |
+| :---- | :---- |
+| `slowQueryLogs` | Fetching slow queries—**prioritize by slowest and most frequent**. Optional: `namespaces` to scope to a collection; `since` for a time window. |
+| `suggestedIndexes` | Fetching cluster index recommendations |
+| `dropIndexSuggestions` | User asks what to remove or reduce index overhead |
+| `schemaSuggestions` | User asks for schema/query-structure advice alongside indexes |
+
+Do not pass the MCP tool name as an `operations` value—`operations` is a separate argument listing what data to fetch.
+
+## Example workflow 1 (help with specific query)
+
+**User:** "Why is this query slow? `db.orders.find({status: 'shipped', region: 'US'}).sort({date: -1})`"
+
+**If MCP db connection is configured and the database + collection names are known**, run steps 1–3. Otherwise skip to step 4.
+
+1. **Check existing collection indexes:**
+   - Call `collection-indexes` with database=`store`, collection=`orders`
+   - Result shows: `{_id: 1}`, `{status: 1}`, `{date: -1}`
+
+2. **Run explain:**
+   - Call `explain` with method=`find`, filter=`{status: 'shipped', region: 'US'}`, sort=`{date: -1}`, verbosity=`queryPlanner` and `executionStats`
+   - Result: Uses `{status: 1}` index, then in-memory SORT, `totalKeysExamined: 50000`, `nReturned: 100`
+
+3. **Run find:**
+   - Call `find` with limit=1 to fetch a sample document to impute the schema.
+
+**If MCP Atlas connection is configured**, run step 4. Otherwise skip to step 5.
+
+4. **Run atlas-get-performance-advisor:**
+   - Try to get the cluster name from the MCP connection string, or ask the user for projectId/clusterName
+   - Use slowQueryLogs to fetch slow query logs from database=`store`, collection=`orders` in the past 24 hours
+   - Use suggestedIndexes to check for index suggestions for the query
+
+5. **Diagnose:** Based on explain output and slow query logs, this query targets 100 docs but scans 50K index entries (poor selectivity: 0.002). In-memory sort adds overhead. Index doesn't support both filter fields or sort.
+
+6. **Recommend:** Create compound index `{status: 1, region: 1, date: -1}` following ESR (two equality fields, then sort). This eliminates in-memory sort and improves selectivity by filtering on both status and region.
+
+If the MongoDB MCP server is not set up, follow best indexing practices.
+
+## Example workflow 2 (general database performance help)
+
+**User:** "Can you help with optimizing slow queries on my cluster?”
+
+1. **Run atlas-get-performance-advisor:**  
+   - Try to get the cluster name from the connection string and deduce the project name you need in atlas-list-projects; if you are not sure, then ask the user for cluster name and project id.
+   - Use slowQueryLogs to fetch slow query logs from the past 24 hours  
+   - Use suggestedIndexes  
+   - Use dropIndexSuggestions  
+   - Use schemaSuggestions  
+2. **Diagnose and Recommend:** Based on slow query logs and performance advisor advice, you can create the compound index `{status: 1, region: 1, date: -1}` on the `db.orders` collection to optimize queries such as `find({status: 'shipped', region: 'US'}).sort({date: -1})`
+
+Examine all performance advisor output as well as slow query logs. Provide information on what is being improved and why, and focus on suggestions that have the potential for greatest impact (e.g., indexes that affect the most queries, or queries that have the worst performance).
+
+## Load references
+
+Before beginning diagnosis and recommendation, load reference files.
+
+Always load:
+
+- `references/core-indexing-principles.md`
+- `references/antipattern-examples.md`
+
+Conditionally load these files:
+
+- **If diagnosing aggregation pipelines** → `references/aggregation-optimization.md`
+- **If diagnosing queries that change docs such as replaceOne, findOneAndUpdate, etc.** → `references/update-query-examples.md` for oplog-efficient updates and common update anti-patterns
+
+## Output
+
+- Keep answers short and clear: a few sentences on index and optimization suggestions, and reasoning behind them (e.g. general indexing principles, observing slow query logs in the cluster, or seeing advice in Performance Advisor)
+- Focus on highest impact indexes or optimizations - if you've omitted some optimizations let the user know and present them if asked.
+- Do not use strong language, such as saying “You should create these indexes and they will definitely improve application performance” \-  Explain they are suggestions for certain queries, and give the reasoning behind them.
+- Consider how many indexes already exist on the collection (if known) \- there shouldn’t generally be more than 20
+- Suggest removing indexes only if the suggestion comes from Atlas Performance Advisor
+- Do not create indexes directly via MCP unless the user gives approval

--- a/.agents/skills/mongodb-query-optimizer/references/aggregation-optimization.md
+++ b/.agents/skills/mongodb-query-optimizer/references/aggregation-optimization.md
@@ -1,0 +1,210 @@
+# Principles
+
+Aggregation pipelines process documents through sequential stages. Focus on:
+
+- Reducing documents early in the pipeline
+- Minimizing data moved between stages
+- Leveraging indexes where possible
+- Managing memory usage
+
+## Memory limits and disk spilling
+
+Blocking stages (such as in-memory `$sort` and `$group`) have a 100MB memory limit per stage. Default behavior when this limit is exceeded is to spill to disk automatically (`allowDiskUse` defaults to `true`).
+
+**Better solutions:**
+
+- Filter more aggressively early in pipeline
+- Add indexes to enable `$sort` to use index order
+- Use `$limit` with `$sort` to reduce the amount of data the sort must process in memory for unindexed sorts
+- Consider materialized views for repeated aggregations
+
+# Optimization Examples
+
+These examples are not exhaustive but representative of some common optimization patterns.
+
+## Unindexed $lookup vs. Indexed $lookup
+
+**Bad** — No index on the foreign collection's join field:
+
+```javascript
+db.orders.aggregate([
+  { $lookup: {
+      from: "products",
+      localField: "productId",
+      foreignField: "sku",   // no index on products.sku!
+      as: "product"
+  }}
+])
+```
+
+**Good** — Index on `foreignField` in the foreign collection:
+
+```javascript
+db.products.createIndex({ sku: 1 })
+
+db.orders.aggregate([
+  { $lookup: {
+      from: "products",
+      localField: "productId",
+      foreignField: "sku",
+      as: "product"
+  }}
+])
+```
+
+**Why:** Each `$lookup` executes a find on the `from` collection. Without an index on `foreignField`, every join does a full collection scan. This is the single most critical $lookup optimization.
+
+## Early $project Defeating Optimization vs. Late $project
+
+**Bad** — Early `$project` prevents the optimizer from pruning unused fields, forgets to exclude `_id` which is unneeded, and includes `name` which is not used:
+
+```javascript
+db.collection.aggregate([
+  { $project: { name: 1, status: 1, amount: 1 } },
+  { $match: { status: "active" } },
+  { $group: { _id: "$status", total: { $sum: "$amount" } } }
+])
+```
+
+**Good** — Let the optimizer handle field pruning; use `$project` only at the end for reshaping:
+
+```javascript
+db.collection.aggregate([
+  { $match: { status: "active" } },
+  { $group: { _id: "$status", total: { $sum: "$amount" } } },
+  { $project: { _id: 0, status: "$_id", total: 1 } }  // reshape at the end
+])
+```
+
+**Why:** MongoDB's pipeline optimizer automatically analyzes which fields are used and avoids fetching unused ones. An early `$project` defeats this optimization, and can inadvertently request the wrong fields.
+
+## $facet for Divergent Processing vs. $unionWith
+
+**Bad** — `$facet` sends all documents to every branch, even if branches need very different subsets:
+
+```javascript
+db.collection.aggregate([
+  { $facet: {
+      "top10": [{ $sort: { score: -1 } }, { $limit: 10 }],
+      "totalCount": [{ $count: "n" }]  // gets ALL docs even though it's just counting
+  }}
+])
+```
+
+**Good** — Separate pipelines via `$unionWith` let each branch optimize independently:
+
+```javascript
+db.collection.aggregate([
+  { $sort: { score: -1 } }, { $limit: 10 },
+  { $unionWith: {
+      coll: "collection",
+      pipeline: [{ $count: "n" }]
+  }}
+])
+```
+
+**Why:** `$facet` funnels every document into every branch. `$unionWith` runs independent pipelines that each benefit from their own index usage and optimization.
+
+## $sort \+ $limit as Separate Concerns vs. Top-N Sort
+
+**Bad** — Large sort, then limit (MongoDB may sort entire dataset):
+
+```javascript
+db.collection.aggregate([
+  { $group: { _id: "$category", total: { $sum: "$amount" } } },
+  { $sort: { total: -1 } },
+  // ... many stages later ...
+  { $limit: 10 }
+])
+```
+
+**Good** — Place `$limit` immediately after `$sort`:
+
+```javascript
+db.collection.aggregate([
+  { $group: { _id: "$category", total: { $sum: "$amount" } } },
+  { $sort: { total: -1 } },
+  { $limit: 10 }
+])
+```
+
+**Why:** When `$sort` is immediately followed by `$limit`, MongoDB performs a *top-N sort* — it only tracks the top N values instead of sorting the full dataset. Far less memory.
+
+## $unwind Best Practices
+
+**When $unwind is needed**, filter before unwinding so that the $match stage allows index usage:
+
+```javascript
+[
+  { $match: { "items.category": "electronics" } },  // Reduce documents first
+  { $unwind: "$items" },  // Then unwind
+  { $match: { "items.category": "electronics" } }  // Filter unwound elements
+]
+```
+
+**Never $unwind to re-group by `_id`:** If you are using `$unwind` followed by `$group` with `_id:` you can replace it with an array operator like `$filter`, `$map` or `$reduce` to match or transform array elements without unwinding.
+
+## Optimize $lookup operations
+
+`$lookup` performs collection joins and can be expensive. Strategies to improve performance:
+
+1. **Filter before lookup** to reduce left-side documents
+2. **Use indexed fields** in the lookup `localField`/`foreignField`
+3. **Add $match in the lookup pipeline** to reduce right-side documents early
+4. **Add $project last in the lookup pipeline** to keep only the fields you need
+5. **$unwind immediately after lookup** when you need `as` result flattened
+
+```javascript
+[
+  { $match: { active: true } },  // Reduce left side
+  { $lookup: {
+      from: "inventory",
+      localField: "product_id",
+      foreignField: "_id",  // _id is always indexed
+      pipeline: [
+        { $match: { inStock: true } },  // Reduce right side
+        { $project: { _id: 0, name: 1, price: 1 } }
+      ],
+      as: "product"
+  }},
+  { $unwind: "$product" }
+]
+```
+
+**Schema consideration:** Excessive `$lookup` usage may indicate over-normalization. Consider embedding frequently-joined data.
+
+## $group efficiency
+
+Group operations require accumulating result documents in memory. Keys to efficiency:
+
+1. **Include only needed fields within the $group stage** \- reference only the fields you need in accumulators
+2. **Be mindful of unbounded accumulators** \- `$push` and `$addToSet` grow as group size increases and can cause memory issues
+
+**Bad** \- do not add $project before $group to "reduce fields":
+
+```javascript
+[
+  { $match: { date: { $gte: ISODate("2024-01-01") } } },
+  { $project: { category: 1, amount: 1 } },
+  { $group: {
+      _id: "$category",
+      total: { $sum: "$amount" },
+      count: { $sum: 1 }
+  }}
+]
+```
+
+**Good** \- reference only needed fields directly in $group:
+
+```javascript
+[
+  { $match: { date: { $gte: ISODate("2024-01-01") } } },
+  { $group: {
+      _id: "$category",
+      total: { $sum: "$amount" },
+      count: { $sum: 1 }
+  }}
+]
+```
+
+**Why:** The $group stage only processes the fields referenced in its expressions. Adding a $project before it does not save memory.

--- a/.agents/skills/mongodb-query-optimizer/references/antipattern-examples.md
+++ b/.agents/skills/mongodb-query-optimizer/references/antipattern-examples.md
@@ -1,0 +1,74 @@
+## $exists on Regular Index vs. Sparse Index
+
+**Bad** — `$exists: true` on a regular index still requires a document fetch:
+
+```javascript
+db.collection.createIndex({ a: 1 })
+db.collection.find({ a: { $exists: true } })
+// Cannot efficiently answer — null semantics require checking each document
+```
+
+**Good** — Use a sparse index, which only contains entries where the field exists:
+
+```javascript
+db.collection.createIndex({ a: 1 }, { sparse: true })
+db.collection.find({ a: { $exists: true } })
+// Answered directly from the index — no document fetch needed
+```
+
+**Why:** Regular indexes store `null` for both missing and existing fields that are set to `null`, so `$exists` can't be answered from the index alone. Sparse indexes only store entries for documents where the field exists.
+
+## Unanchored $regex vs. Anchored $regex
+
+**Bad** — Unanchored case insensitive regex cannot use the index efficiently:
+
+```javascript
+db.collection.find({ name: { $regex: /smith/i } })
+// Full index or collection scan — case-insensitive, not anchored
+```
+
+**Good** — Anchored, case-sensitive regex uses the index as a range query:
+
+```javascript
+db.collection.find({ name: { $regex: /^Smith/ } })
+// Efficient index range scan on the "Smith" prefix
+```
+
+**Why:** Indexes store values in sorted order. Only a left-anchored, case-sensitive `$regex` can be converted into an efficient index range scan. For case-insensitive matching, use a case-insensitive collation index instead.
+
+## $where / JavaScript vs. Native MQL Operators
+
+**Bad** — Server-side JavaScript execution:
+
+```javascript
+db.collection.find({
+  $where: "this.price * this.quantity > 1000"
+})
+```
+
+**Good** — Native aggregation expression:
+
+```javascript
+db.collection.find({
+  $expr: { $gt: [{ $multiply: ["$price", "$quantity"] }, 1000] }
+})
+```
+
+**Why:** JavaScript executed on the server is always slower than native MQL, cannot use indexes. It's also a security risk and is deprecated. Use `$expr` with aggregation operators instead.
+
+## In-Memory Sort vs. Index-Supported Sort
+
+**Bad** — Sort on an unindexed field triggers in-memory sort:
+
+```javascript
+db.orders.find({ status: "processing" }).sort({ createdAt: -1 })
+// Index: { status: 1 } — sort is done in memory
+```
+
+**Good** — Compound index supports both filter and sort:
+
+```javascript
+db.orders.createIndex({ status: 1, createdAt: -1 })
+db.orders.find({ status: "processing" }).sort({ createdAt: -1 })
+// No SORT stage in the plan — results come pre-sorted from the index
+```

--- a/.agents/skills/mongodb-query-optimizer/references/core-indexing-principles.md
+++ b/.agents/skills/mongodb-query-optimizer/references/core-indexing-principles.md
@@ -1,0 +1,134 @@
+# Core Index Principles
+
+### Compound Index Guidelines
+
+The first field of the index should be in the query's filter or sort condition.
+
+**Equality → Sort → Range** order is most often preferred:
+
+- **Equality** fields first (e.g. `{field: value}`, `{$in: [...]}` with \<= 200 elements, `{field: {$eq: value}}`)
+- **Sort** fields next  
+- **Range** fields last (e.g. `$gt`, `$lt`, `$gte`, `$lte`, `{$in: [...]}` with \> 200 elements in the array, `$ne`, anchored case-sensitive `$regex`)
+
+If equality is not very selective and range is, then ERS may perform better than ESR.
+
+### Sort direction
+
+Index `{a:1, b:1}` supports `sort({a:1, b:1})` and reverse `sort({a:-1, b:-1})`, but NOT mixed directions like `sort({a:1, b:-1})`. For mixed sorts, create index matching exact pattern.
+
+### Collation Match
+
+**Before** — Query collation differs from index collation, so the index cannot be used:
+
+```javascript
+db.users.createIndex({ name: 1 })
+db.users.find({ name: "José" }).collation({ locale: "es", strength: 2 })
+// Index cannot be used for query
+```
+
+**After** — Create the index with the same collation the query uses:
+
+```javascript
+db.users.createIndex({ name: 1 }, { collation: { locale: "es", strength: 2 } })
+db.users.find({ name: "José" }).collation({ locale: "es", strength: 2 })
+// Index can be used for query
+```
+
+**Why:** Collation must match between index and query.
+
+# Covered Queries
+
+A covered query retrieves data directly from the index, never accessing the actual documents. This is extremely fast and preferable when possible.
+
+## Requirements
+
+1. **All query fields** are in the index  
+2. **All returned fields** are in the index (includes sort fields)  
+3. **Inclusion projection required** \- you must use an inclusion projection (e.g., `{ field: 1 }`) that requests only indexed fields, plus `_id: 0` if `_id` is not in the index. Exclusion projections cannot produce covered queries.  
+4. **No `$exists` or null equality checks** \- queries using `$exists` or querying for null/missing values cannot usually be covered by an index
+5. **Multikey index constraints** \- multikey indexes can cover queries under certain conditions, such as when the array field itself is not included in the projection and operators like `$elemMatch` are not used. If the array field must be projected, covering is not possible.
+
+## Building a covered query
+
+**Step 1:** Identify your query pattern
+
+```javascript
+db.products.find(
+  { category: "electronics", inStock: true },
+  { category: 1, inStock: 1, price: 1, _id: 0 }
+).sort({ price: 1 })
+```
+
+**Step 2:** Create index with all accessed fields
+
+Following ESR (Equality-Sort-Range):
+
+```javascript
+db.products.createIndex({
+  category: 1,    // Equality
+  inStock: 1,     // Equality
+  price: 1        // Sort
+})
+```
+
+**Step 3:** Project only indexed fields
+
+- Include indexed fields in projection  
+- **Exclude \_id** unless \_id is in the index (use `_id: 0`)  
+- Don't request fields not in the index
+
+## Common mistakes
+
+### Forgetting to explicitly exclude  \_id
+
+```javascript
+// NOT COVERED - _id not in index but included in result
+db.products.find(
+  { category: "electronics" },
+  { category: 1, price: 1 }  // _id included by default!
+)
+```
+
+**Fix:** Explicitly exclude \_id
+
+```javascript
+db.products.find(
+  { category: "electronics" },
+  { category: 1, price: 1, _id: 0 }  // Now covered
+)
+```
+
+### Requesting non-indexed fields
+
+```javascript
+// NOT COVERED - description not in index
+db.products.find(
+  { category: "electronics" },
+  { category: 1, price: 1, description: 1, _id: 0 }
+)
+```
+
+**Fix:** Only project indexed fields, or add description to index
+
+### Array fields (multikey indexes)
+
+```javascript
+// NOT COVERED - tags is an array field and is included in projection
+db.products.createIndex({ tags: 1, price: 1 })
+db.products.find(
+  { tags: "sale" },
+  { tags: 1, price: 1, _id: 0 }
+)
+```
+
+**Fix:** If the array field is not needed in the result, remove it from the projection:
+
+```javascript
+// COVERED - array field (tags) used in query but not projected
+db.products.find(
+  { tags: "sale" },
+  { price: 1, _id: 0 }
+)
+```
+
+Multikey indexes can cover queries when the array field itself is not projected and operators like `$elemMatch` are not used. If you must return the array field, the query cannot be covered.

--- a/.agents/skills/mongodb-query-optimizer/references/update-query-examples.md
+++ b/.agents/skills/mongodb-query-optimizer/references/update-query-examples.md
@@ -1,0 +1,39 @@
+# Update Query Examples
+
+## replaceOne vs. updateOne with $replaceWith
+
+**Bad** — Full document replacement generates a large oplog entry:
+
+```javascript
+db.coll.replaceOne({ _id: X }, entireNewDocument)
+```
+
+**Good** — Use aggregation-based update to generate smaller oplog deltas:
+
+```javascript
+db.coll.updateOne({ _id: X }, [{ $replaceWith: { $literal: entireNewDocument } }])
+```
+
+**Why:** `replaceOne` writes the full document to the oplog. The aggregation update syntax lets MongoDB compute deltas, resulting in smaller oplog entries when only a few fields are changed.
+
+## findOneAndUpdate Misuse vs. updateOne
+
+**Bad** — Using `findOneAndUpdate` when you don't need the document returned:
+
+```javascript
+db.coll.findOneAndUpdate(
+  { _id: X },
+  { $set: { status: "processed" } }
+)
+```
+
+**Good** — Use `updateOne` when you don't need the result document:
+
+```javascript
+db.coll.updateOne(
+  { _id: X },
+  { $set: { status: "processed" } }
+)
+```
+
+**Why:** `findOneAndUpdate` writes a copy of the pre-change document to a side collection for retryable writes. This overhead is unnecessary if you don't need the returned document.

--- a/.agents/skills/mongodb-schema-design/SKILL.md
+++ b/.agents/skills/mongodb-schema-design/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: mongodb-schema-design
+description: MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL, or troubleshooting performance issues caused by schema problems. Triggers on "design schema", "embed vs reference", "MongoDB data model", "schema review", "unbounded arrays", "one-to-many", "tree structure", "16MB limit", "schema validation", "JSON Schema", "time series", "schema migration", "polymorphic", "TTL", "data lifecycle", "archive", "index explosion", "unnecessary indexes", "approximation pattern", "document versioning".
+license: Apache-2.0
+metadata:
+  version: "1.0.0"
+---
+
+# MongoDB Schema Design
+
+Data modeling patterns and anti-patterns for MongoDB, maintained by MongoDB. Bad schema is the root cause of most MongoDB performance and cost issues—queries and indexes cannot fix a fundamentally wrong model.
+
+## When to Apply
+
+Reference these guidelines when:
+- Designing a new MongoDB schema from scratch
+- Migrating from SQL/relational databases to MongoDB
+- Reviewing existing data models for performance issues
+- Troubleshooting slow queries or growing document sizes
+- Deciding between embedding and referencing
+- Modeling relationships (one-to-one, one-to-many, many-to-many)
+- Implementing tree/hierarchical structures
+- Seeing Atlas Schema Suggestions or Performance Advisor warnings
+- Hitting the 16MB document limit
+- Adding schema validation to existing collections
+
+## Quick Reference
+
+### 1. Schema Anti-Patterns - 3 rules
+
+- [antipattern-unnecessary-collections](references/antipattern-unnecessary-collections.md) - Splitting homogeneous data into multiple collections is often an anti-pattern; consult this reference to validate whether this is the case.
+- [antipattern-excessive-lookups](references/antipattern-excessive-lookups.md) - When encountering overly normalized collections that reference each other or frequent and possibly slow $lookup operations, consult this reference to validate whether this is problematic and how to fix it.
+- [antipattern-unnecessary-indexes](references/antipattern-unnecessary-indexes.md) - Consult this reference when indexes overlap or are not used by queries, to identify and remove unnecessary indexes that add overhead without benefit.
+
+### 2. Schema Fundamentals - 4 rules
+
+- [fundamental-embed-vs-reference](references/fundamental-embed-vs-reference.md) - Consult this reference for approaches to modeling different types of relationships (1:1, 1:few, 1:many, many:many, tree/hierarchical data) and how to decide between embedding and referencing based on access patterns.
+- [fundamental-document-model](references/fundamental-document-model.md) - Fundamentals of the document model. Consult this reference when migrating from SQL or other normalized data to a document database like MongoDB.
+- [fundamental-schema-validation](references/fundamental-schema-validation.md) - Consult this reference when creating new collections, or adding validation to existing collections, for example in response to finding inconsistent document structures or data quality issues.
+- [fundamental-document-size](references/fundamental-document-size.md) - Consult this reference when documents hit the hard 16MB limit, or when accesses are slower than expected as a result of large documents.
+
+### 3. Design Patterns - 11 rules
+
+- [pattern-approximation](references/pattern-approximation.md) - Use approximate values for high-frequency counters
+- [pattern-archive](references/pattern-archive.md) - Move historical data to separate/cold storage for performance
+- [pattern-attribute](references/pattern-attribute.md) - Collapse many optional fields into key-value attributes
+- [pattern-bucket](references/pattern-bucket.md) - Group time-series or IoT data into buckets
+- [pattern-computed](references/pattern-computed.md) - Pre-calculate expensive aggregations
+- [pattern-document-versioning](references/pattern-document-versioning.md) - Track document changes to enable historical queries and audit trails
+- [pattern-extended-reference](references/pattern-extended-reference.md) - Cache frequently-accessed data from related entities
+- [pattern-outlier](references/pattern-outlier.md) - Handle collections in which a small subset of documents are much larger than the rest, to prevent outliers from dominating memory and index costs
+- [pattern-polymorphic](references/pattern-polymorphic.md) - Store different types of entities in the same collection, often when they are different types of the same base entity (e.g. different types of users or different types of products)
+- [pattern-schema-versioning](references/pattern-schema-versioning.md) - Schema evolution, preventing drift, and safe online migrations. Consult when encountering inconsistent document structures, or when planning a schema change that cannot be applied atomically.
+- [pattern-time-series-collections](references/pattern-time-series-collections.md) - Use native time series collections for high-frequency time series data
+
+### Access Pattern Analysis
+
+Do not immediately recommend a pattern or schema change without understanding the broader context. Together with the user, analyze access patterns to identify pain points and opportunities for optimization.
+
+#### Workflow
+
+**Step 1: Assess the environment**
+Ask the user:
+  - Is this a new design or is there a production database with existing access patterns to analyze?
+  - If there is production data, is it on Atlas? If yes, what tier? (M0/M2/M5 vs M10+)
+
+**Step 2: Determine workload type**
+Is the workload read-heavy, write-heavy, or balanced? This will influence which diagnostic sources are most relevant.
+Ask the user:
+- What's the primary workload for these collections — read-heavy (analytics, reports, searches), write-heavy (logging, IoT ingestion, frequent updates), or balanced?
+
+Verify with `db.serverStatus().opcounters`.
+
+**Step 3: Work with the user to choose the best source(s)**
+  Recommend the best source(s) for their situation, explaining the tradeoffs. For schema design decisions, we often need to combine multiple sources for a complete picture.
+
+**Step 4: Proceed with analysis**
+  Only after source selection, fetch data or guide the user through analysis.
+
+#### Sources
+
+- [Query statistics](references/source-query-stats.md) - Returns runtime statistics for recorded queries showing query shapes and frequency. **Limitation**: Currently only captures read operations (pair with other sources for write patterns). Requires Atlas M10+ tier.
+- [Atlas Slow Query Logs](references/source-slow-query-logs.md) - Review slow queries (actual queries, not shapes) to identify performance bottlenecks. Captures all reads and writes. Requires Atlas M10+ tier.
+- Codebase - Examine actual queries in application code to understand access patterns, especially for new applications or with changing workloads. Can be used in conjunction with query stats for a more complete picture.
+- Natural language input - Ask the user to describe their typical queries and access patterns in natural language. Can be used as the only source or to supplement and validate other sources - the user might have contextual knowledge that is not reflected in the data or codebase.
+
+**Combining Query Stats and Slow Query Logs:**
+
+Use both together for comprehensive analysis:
+1. Query Stats → identify frequent access patterns (which queries run most often)
+2. Slow Query Logs → identify performance bottlenecks (which queries are slow)
+3. Focus schema optimization on queries that are both frequent AND slow (highest impact)
+
+## Key Principle
+
+> **"Data that is accessed together should be stored together."**
+
+This is MongoDB's core philosophy. Embedding related data eliminates joins, reduces round trips, and enables atomic updates. Reference only when you must.
+
+A core way to implement this philosophy is the fact that MongoDB exposes **flexible schemas**. This means you can have different fields in different documents, and even different structures. This allows you to model data in the way that best fits your access patterns, without being constrained by a rigid schema. For example, if different documents have different sets of fields, that is perfectly fine as long as it serves your application's needs. You can also use schema validation to enforce certain rules while still allowing for flexibility.
+
+Another implication of the key principle is that information about the expected read and write workload becomes very relevant to schema design. If pieces of information from different entities are often queried or updated together, that means that prioritizing co-location of that data in the same document can lead to significant performance benefits. On the other hand, if certain pieces of information are rarely accessed together, it may make sense to store them separately to avoid loading more data than necessary.
+
+#### Schema Fundamentals Summary
+
+- **Embed vs Reference**: Choose embedding or referencing based on access patterns: embed when data is always accessed together (1:1, 1:few, bounded arrays, atomic updates needed); reference when data is accessed independently, relationships are many-to-many, or arrays can grow without bound.
+- **Data accessed together stored together**: MongoDB's core principle: design schemas around queries, not entities. Embed related data to eliminate cross-collection joins and reduce round trips. Identify your API endpoints/pages, list the data each returns, then shape documents to match those queries.
+- **Embrace the document model**: Don't recreate SQL tables 1:1 as MongoDB collections. Instead, denormalize joined tables into rich documents for single-query reads and atomic updates. When migrating from SQL, identify tables that are always joined together and merge them into single documents.
+- **Schema validation**: Use MongoDB's built-in `$jsonSchema` validator to catch invalid data at the database level (type checks, required fields, enum constraints, array size limits). Start with `validationLevel: "moderate"` and `validationAction: "warn"` on existing collections, then tighten to `strict`/`error`.
+- **16MB document limit**: MongoDB documents cannot exceed 16MB—this is a hard limit, not a guideline. Common causes: unbounded arrays, large embedded binaries, deeply nested objects. Mitigate by moving unbounded data to separate collections and monitoring document sizes with `$bsonSize`.
+
+## Embed/Reference Decision Framework
+
+| Relationship | Cardinality | Access Pattern | Recommendation |
+|-------------|-------------|----------------|----------------|
+| One-to-One | 1:1 | Always together | Embed |
+| One-to-Few | 1:N (N < 100) | Usually together | Embed array |
+| One-to-Many | 1:N (N > 100) | Often separate | Reference |
+| Many-to-Many | M:N | Varies | Two-way reference |
+
+This is a **rough** guideline, and whether to embed or reference depends on your specific access patterns, data size, and read/write frequencies. Always verify with your actual workload.
+
+## How to Use
+
+Each reference file listed above contains detailed explanations and code examples. Use the descriptions in the Quick Reference to identify which files are relevant to your current task.
+
+Each reference file contains:
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation
+- "When NOT to use" exceptions
+- Performance impact and metrics
+- Verification diagnostics
+
+---
+
+## How These Rules Work
+
+### MongoDB MCP Integration
+
+For automatic verification, connect the [MongoDB MCP Server](https://github.com/mongodb-js/mongodb-mcp-server).
+
+If the MCP server is running and connected, I can automatically run verification commands to check your actual schema, document sizes, array lengths, index usage, slow query logs, and more. This allows me to provide tailored recommendations based on your real data, not just code patterns.
+
+**⚠️ Security**: Use `--readOnly` for safety. Remove only if you need write operations.
+
+When connected, I can automatically:
+- Infer schema via `mcp__mongodb__collection-schema`
+- Measure document/array sizes via `mcp__mongodb__aggregate`
+- Check collection statistics via `mcp__mongodb__db-stats`
+
+### ⚠️ Action Policy
+
+**I will NEVER execute write operations without your explicit approval.**
+
+Before any write or destructive operation via MCP, I will: (1) summarize the exact operation (collection, index/validator, estimated number of docs affected), and (2) ask for explicit confirmation (yes/no). I will not proceed on partial or ambiguous approvals.
+
+| Operation Type | MCP Tools | Action |
+|---------------|-----------|--------|
+| **Read (Safe)** | `find`, `aggregate`, `collection-schema`, `db-stats`, `count` | I may run automatically to verify |
+| **Write (Requires Approval)** | `update-many`, `insert-many`, `create-collection` | I will show the command and wait for your "yes" |
+| **Destructive (Requires Approval)** | `delete-many`, `drop-collection`, `drop-database` | I will warn you and require explicit confirmation |
+
+When I recommend schema changes or data modifications:
+1. I'll explain **what** I want to do and **why**
+2. I'll show you the **exact command**
+3. I'll **wait for your approval** before executing
+4. If you say "go ahead" or "yes", only then will I run it
+
+**Your database, your decision.** I'm here to advise, not to act unilaterally.
+
+### Working Together
+
+If you're not sure about a recommendation:
+1. Run the verification commands I provide
+2. Share the output with me
+3. I'll adjust my recommendation based on your actual data
+
+We're a team—let's get this right together.
+
+

--- a/.agents/skills/mongodb-schema-design/references/antipattern-excessive-lookups.md
+++ b/.agents/skills/mongodb-schema-design/references/antipattern-excessive-lookups.md
@@ -1,0 +1,84 @@
+---
+title: Reduce Excessive $lookup Usage
+impact: CRITICAL
+impactDescription: "Can reduce query cost on hot paths by avoiding repeated cross-collection joins"
+tags: schema, lookup, anti-pattern, joins, denormalization, atlas-suggestion
+---
+
+## Reduce Excessive $lookup Usage
+
+**Frequent $lookup operations on hot paths can indicate over-normalization.** `$lookup` is useful, but repeated joins can be slower and more resource-intensive than querying a single collection, especially when supporting indexes or match selectivity are weak. If the same related fields are read together often, consider embedding or extended references.
+
+**Incorrect (constant $lookup for common operations):**
+
+```javascript
+// Every product page requires repeated joins across collections
+db.products.aggregate([
+  { $match: { _id: productId } },
+  { $lookup: {
+      from: "categories",          // Collection scan #2
+      localField: "categoryId",
+      foreignField: "_id",
+      as: "category"
+  }},
+  { $lookup: {
+      from: "brands",              // Collection scan #3
+      localField: "brandId",
+      foreignField: "_id",
+      as: "brand"
+  }},
+  { $unwind: "$category" },
+  { $unwind: "$brand" }
+])
+// Multiple join stages add planning/execution overhead on hot paths
+```
+
+Join cost depends on cardinality, stage order, index support, and result size. Measure before deciding to embed.
+
+**Correct (denormalize frequently-joined data):**
+
+Embed data that is always displayed alongside the product directly in the product document: include category fields (`_id`, `name`, `path`) and brand fields (`_id`, `name`, `logo`) as subdocuments. A single indexed query returns complete product data without `$lookup`. Listing queries (e.g. by category) also run against a single collection.
+
+**Managing denormalized data updates:**
+
+When category data changes (a rare event), use `updateMany` to update all products matching that category’s `_id` with the new field values. For frequently-changing data, keep both a reference ID (`brandId`) and a cache subdocument (`brandCache`) with a `cachedAt` timestamp; refresh the cache when it exceeds a staleness threshold.
+
+**When NOT to use this pattern:**
+
+- **Data changes frequently and independently**: If brand logos change daily, denormalization creates update overhead.
+- **Rarely-accessed data**: Don't embed review details if only a small fraction of product views load reviews.
+- **Many-to-many with high cardinality**: Avoid embedding large or fast-growing relationship sets.
+- **Analytics queries**: Batch jobs can afford $lookup latency; real-time queries cannot.
+
+## Verify with
+
+####  Find pipelines with $lookup stages 
+
+For Atlas M10+ use $queryStats. See [Query Stats](references/source-query-stats.md)
+Use codebase if available, ask the user.
+
+```javascript
+
+// Check if $lookup foreign fields are indexed
+
+// Example A - $indexStats
+db.categories.aggregate([
+  { $indexStats: {} }
+])
+
+// Example B - getIndexes()
+db.categories.getIndexes()
+
+// Look for index supporting the query (either a direct index on the foreign field or a compound index that has the foreign field as a prefix, note the collation)
+
+// Measure $lookup impact
+db.products.aggregate([
+  { $match: { category: "electronics" } },
+  { $lookup: { from: "brands", localField: "brandId", foreignField: "_id", as: "brand" } }
+]).explain("executionStats")
+// Check totalDocsExamined in $lookup stage
+```
+
+Atlas Schema Suggestions flags: "Reduce $lookup operations"
+
+Reference: [Reduce Lookup Operations](https://mongodb.com/docs/manual/data-modeling/design-antipatterns/reduce-lookup-operations/)

--- a/.agents/skills/mongodb-schema-design/references/antipattern-unnecessary-collections.md
+++ b/.agents/skills/mongodb-schema-design/references/antipattern-unnecessary-collections.md
@@ -1,0 +1,91 @@
+---
+title: Reduce Unnecessary Collections
+impact: CRITICAL
+impactDescription: "Reduces avoidable joins when related data is repeatedly queried together"
+tags: schema, collections, anti-pattern, embedding, normalization, atlas-suggestion
+---
+
+## Reduce Unnecessary Collections
+
+**Collection count alone is not the anti-pattern.** The anti-pattern is using collections as a substitute for indexes — creating one collection per category, time period, or partition key instead of indexing a single collection. Every collection carries a default `_id` index that consumes storage and strains the replica set, and cross-collection queries require `$lookup` or `$unionWith`, adding complexity and overhead.
+
+**Incorrect (one collection per day as partitioning strategy):**
+
+Creating one collection per time period (e.g. `temperatures_2024_05_10`, `temperatures_2024_05_11`, …) means each collection carries its own default `_id` index (365 collections/year = 365 extra indexes), cross-day queries require `$unionWith` across many collections, schema validation / indexes / TTL must be duplicated on every collection, and application code must dynamically resolve the collection name for each query.
+
+**Correct (single collection with an index):**
+
+```javascript
+// All readings in one collection — the index does the partitioning work
+{ _id: ObjectId(), timestamp: ISODate("2024-05-10T10:00:00Z"), temperature: 60 }
+{ _id: ObjectId(), timestamp: ISODate("2024-05-10T11:00:00Z"), temperature: 61 }
+{ _id: ObjectId(), timestamp: ISODate("2024-05-11T10:00:00Z"), temperature: 68 }
+
+db.temperatures.createIndex({ timestamp: 1 })
+
+// Efficient range query — one collection, one index
+db.temperatures.find({
+  timestamp: { $gte: ISODate("2024-05-10"), $lt: ISODate("2024-05-11") }
+})
+
+// Optional TTL for automatic expiry (e.g. 90 days)
+db.temperatures.createIndex({ timestamp: 1 }, { expireAfterSeconds: 7776000 })
+```
+
+**Even better (bucket pattern or time series collection):**
+
+For high-volume time-stamped data, group readings into buckets or use a native time series collection, which is optimized for this workload:
+
+```javascript
+// Bucket pattern — one document per day
+{
+  _id: ISODate("2024-05-10T00:00:00Z"),
+  readings: [
+    { timestamp: ISODate("2024-05-10T10:00:00Z"), temperature: 60 },
+    { timestamp: ISODate("2024-05-10T11:00:00Z"), temperature: 61 },
+    { timestamp: ISODate("2024-05-10T12:00:00Z"), temperature: 64 }
+  ]
+}
+
+// In this particular case, a native time series collection
+// is also a good option to consider
+db.createCollection("temperatures", {
+  timeseries: { timeField: "timestamp", granularity: "hours" }
+})
+```
+
+**When to use separate collections:**
+
+| Scenario | Separate Collection | Why |
+|----------|--------------------|----|
+| Data accessed independently | Yes | Different query patterns |
+| Unbounded relationships | Yes | Prevents document growth |
+| Many-to-many | Yes | Students ↔ Courses |
+| 1:1 always together | No (embed) | User and profile |
+
+**When NOT to use this pattern:**
+
+- **Data is genuinely independent**: Products exist separately from orders; don't embed full product catalog in every order.
+- **Frequent independent updates**: If customer email changes shouldn't update all historical orders (it shouldn't).
+- **Data is accessed in different contexts**: Same address entity used for shipping, billing, user profile—keep it separate.
+- **Regulatory requirements**: Some industries require normalized data for audit trails.
+
+## Verify with
+
+```javascript
+// Count your collections
+for (const d of db.adminCommand({ listDatabases: 1 }).databases) {
+  const colls = db.getSiblingDB(d.name).getCollectionNames().length
+  print(`${d.name}: ${colls} collections`)
+}
+// Count alone is not sufficient: combine with access and index/storage evidence
+```
+
+### Check if collections are always accessed together.
+
+For Atlas M10+ use $queryStats. See [Query Stats](references/source-query-stats.md)
+Use codebase if available, ask the user.
+
+Atlas Schema Suggestions flags: "Reduce number of collections"
+
+Reference: [Reduce the Number of Collections](https://mongodb.com/docs/manual/data-modeling/design-antipatterns/reduce-collections/)

--- a/.agents/skills/mongodb-schema-design/references/antipattern-unnecessary-indexes.md
+++ b/.agents/skills/mongodb-schema-design/references/antipattern-unnecessary-indexes.md
@@ -1,0 +1,95 @@
+---
+title: "Avoid Unnecessary Indexes"
+impact: CRITICAL
+impactDescription: "Reduces write overhead and WiredTiger cache pressure from unused or redundant indexes"
+tags: schema, antipattern, indexes, performance, atlas-suggestion
+---
+
+## Avoid Unnecessary Indexes
+
+**Every index has a write cost.** On insert, update, and delete, MongoDB must update ALL indexes on the collection. Unused or redundant indexes slow down writes with no query benefit, and consume RAM in the WiredTiger cache competing with working set data. Atlas Performance Advisor specifically flags "Redundant Index" and "Unused Index".
+
+**Incorrect (indexes created "just in case"):**
+
+```javascript
+// Creating indexes speculatively without query evidence
+db.orders.createIndex({ status: 1 })          // never queried by status alone
+db.orders.createIndex({ status: 1, date: 1 }) // already have {status:1,date:1,amount:1}
+db.orders.createIndex({ region: 1 })           // added during development, never used
+
+// Problems:
+// 1. Every insert/update/delete must update ALL indexes
+// 2. Redundant {status: 1} is fully covered by {status: 1, date: 1, amount: 1}
+// 3. Unused indexes waste RAM in WiredTiger cache
+// 4. Atlas Performance Advisor flags these but they're never cleaned up
+```
+
+**Correct (audit-driven index management):**
+
+```javascript
+// Only create indexes that serve real query patterns
+// Audit before adding new indexes:
+db.orders.aggregate([{ $indexStats: {} }])
+
+// Review index list regularly
+db.orders.getIndexes()
+
+// A compound index {a: 1, b: 1} makes a single-field index {a: 1} redundant
+// — the compound index serves all queries that {a: 1} alone serves
+db.col.createIndex({ a: 1 })         // drop this — redundant
+db.col.createIndex({ a: 1, b: 1 })   // keep this
+
+// NOTE: Different leading field is NOT redundant
+db.col.createIndex({ a: 1, b: 1 })
+db.col.createIndex({ b: 1 })         // NOT covered by above — keep
+```
+
+**Safe removal process (hide → monitor → drop):**
+
+```javascript
+// Never drop an index directly in production
+
+// Step 1: Hide the index (invisible to query planner but stays on disk)
+db.orders.hideIndex("status_1")
+
+// Step 2: Monitor for a full workload cycle (days/weeks)
+// If queries degrade, unhide immediately:
+// db.orders.unhideIndex("status_1")
+
+// Step 3: Once confident, permanently drop
+db.orders.dropIndexes(["status_1"])
+```
+
+Atlas automatically flags:
+- **"Redundant Index"** — a prefix of an existing compound index
+- **"Unused Index"** — zero query usage in the observed window
+
+**When NOT to use this pattern:**
+
+- **New collections with planned queries**: If you know queries are coming, pre-creating indexes is fine.
+- **Indexes for rare but critical operations**: A backup or compliance query that runs monthly may show low usage but is still needed.
+- **TTL indexes**: These serve data lifecycle purposes even if not used for queries.
+
+## Verify with
+
+```javascript
+// Find indexes with zero query usage since last restart
+db.orders.aggregate([{ $indexStats: {} }])
+// Look for: accesses.ops: 0
+// Example output:
+// { name: "status_1", accesses: { ops: 0, since: ISODate("...") }, ... }
+// An accesses.ops: 0 after a representative workload period means the index
+// is never used by any query
+
+// Check total index count and sizes
+db.orders.stats().indexSizes
+// Large number of indexes or large total index size signals audit opportunity
+
+// Find redundant indexes (prefix subsets)
+for (const idx of db.orders.getIndexes()) {
+  print(`${idx.name}: ${JSON.stringify(idx.key)}`)
+}
+// Compare index key prefixes — if {a:1} exists alongside {a:1,b:1}, the former is redundant
+```
+
+Reference: [Remove Unnecessary Indexes](https://mongodb.com/docs/manual/data-modeling/design-antipatterns/unnecessary-indexes/)

--- a/.agents/skills/mongodb-schema-design/references/fundamental-document-model.md
+++ b/.agents/skills/mongodb-schema-design/references/fundamental-document-model.md
@@ -1,0 +1,91 @@
+---
+title: Embrace the Document Model
+impact: HIGH
+impactDescription: "Aligns schema to aggregate access patterns and minimizes avoidable cross-collection joins"
+tags: schema, document-model, fundamentals, sql-migration
+---
+
+## Embrace the Document Model
+
+**Don't recreate SQL tables one-to-one in MongoDB.** The document model is designed to store related data together when it is read and updated together. Naively copying relational boundaries often increases application-side joins and coordination logic.
+
+**Incorrect (SQL patterns in MongoDB):**
+
+Mirroring a relational schema 1:1 — e.g. separate `customers`, `addresses`, `phones`, and `preferences` collections linked by `customerId` — requires four queries and four index lookups to load one customer profile, plus application-side joining. Updates may require cross-collection coordination or transactions.
+
+**Correct (rich document model):**
+
+```javascript
+// Customer document contains everything about the customer
+// All data retrieved in single read, updated atomically
+{
+  _id: "cust123",
+  name: "Alice Smith",
+  email: "alice@example.com",
+  addresses: [
+    { type: "home", street: "123 Main", city: "Boston", zip: "02101" },
+    { type: "work", street: "456 Oak", city: "Boston", zip: "02102" }
+  ],
+  phones: [
+    { type: "mobile", number: "555-1234" },
+    { type: "work", number: "555-5678" }
+  ],
+  preferences: {
+    newsletter: true,
+    theme: "dark",
+    language: "en"
+  },
+  createdAt: ISODate("2024-01-01")
+}
+
+// Single query loads complete customer - 1 round-trip
+db.customers.findOne({ _id: "cust123" })
+
+// Atomic update - no transaction needed
+db.customers.updateOne(
+  { _id: "cust123" },
+  { $push: { addresses: newAddress }, $set: { "preferences.theme": "light" } }
+)
+```
+
+**Common tradeoffs:**
+
+| Aspect | SQL-style mapping in MongoDB | Document-first mapping |
+|--------|----------------------------|------------------------|
+| Queries per aggregate view | Often multiple collection reads or `$lookup` | Often one collection read for hot paths |
+| Atomicity for related fields | May require multi-document transaction | Single-document writes are atomic |
+| Schema evolution | More migration/coordination between collections | Often localized changes per document shape |
+| Application logic | More join/merge logic in app | Simpler read model for common operations |
+
+**When migrating from SQL:**
+
+1. Don't convert tables 1:1 to collections
+2. Identify which tables are always joined together
+3. Denormalize those joins into single documents
+4. Keep separate only what's accessed separately
+
+**When NOT to use this pattern:**
+
+- **Genuinely independent data**: If addresses are shared across users or accessed independently, keep them separate.
+- **Unbounded relationships**: User with 10,000 orders should NOT embed all orders.
+- **Regulatory requirements**: Some compliance rules require normalized audit trails.
+
+## Verify with
+
+```javascript
+// Count your collections vs expected entities
+for (const d of db.adminCommand({ listDatabases: 1 }).databases) {
+  const colls = db.getSiblingDB(d.name).getCollectionNames().length
+  print(`${d.name}: ${colls} collections`)
+}
+// Collection count alone is not enough evidence; inspect query/access patterns too
+
+// Check for SQL-style foreign key patterns
+db.addresses.aggregate([
+  { $group: { _id: "$customerId", count: { $sum: 1 } } },
+  { $match: { count: { $gt: 0 } } }
+]).itcount()
+// If addresses always belong to customers, they should be embedded
+```
+
+Reference: [Schema Design Process](https://mongodb.com/docs/manual/data-modeling/schema-design-process/)

--- a/.agents/skills/mongodb-schema-design/references/fundamental-document-size.md
+++ b/.agents/skills/mongodb-schema-design/references/fundamental-document-size.md
@@ -1,0 +1,226 @@
+---
+title: Keep Documents Small
+impact: CRITICAL
+impactDescription: "Hard 16MB BSON limit; oversized documents fail writes and degrade performance long before that"
+tags: schema, fundamentals, document-size, 16mb, bson-limit, arrays, anti-pattern, performance, indexing, subset-pattern, working-set, hot-data, cold-data, atlas-suggestion
+---
+
+## Keep Documents Small
+
+**MongoDB documents cannot exceed 16 megabytes.** This is a hard BSON limit, not a guideline — writes fail once a document reaches it.
+
+However, practical documents should be **much smaller than 16MB**. As a rule of thumb, aim for documents **under 1MB**. Smaller documents mean:
+
+- **Better working-set efficiency** — more documents fit in the WiredTiger cache.
+- **Faster reads and writes** — less data copied, serialized, and transferred per operation.
+- **Lower replication overhead** — smaller oplog entries replicate faster.
+- **Room to grow** — a document well under the limit won't surprise you after a year of appended data.
+
+The 16MB ceiling is a safety net, not a design target.
+
+### How documents get too large
+
+1. **Unbounded arrays** — e.g. an `activityLog` array receiving entries on every user action: 100,000 events × ~150 bytes ≈ 15MB, growing until writes are rejected.
+2. **Large bounded arrays** — even a bounded comments array (5,000 items × ~500 bytes = 2.5MB) is expensive: each `$push` rewrites the growing document, and a multikey index fans out to one entry per element.
+3. **Bloated documents with cold fields** — MongoDB reads full documents, even when queries only need a few fields. A product document carrying name and price (~18 bytes, frequently needed) alongside description (~5KB), full specs (~10KB), base64 images (~500KB), reviews (~100KB), and price history (~50KB) can reach ~665KB. Hot-path queries still load the entire document into cache, reducing working-set density. Even projecting a small field set (e.g. `db.products.find({}, {name: 1, price: 1})`) still reads the full document from storage.
+4. **Large embedded binary** — a `BinData` PDF attachment of 10MB+; additional attachments push the document past the limit.
+5. **Deeply nested objects** — a configuration document with 100+ nesting levels where metadata and keys alone approach 16MB.
+
+### Solution 1: move unbounded or large data to a separate collection
+
+Keep the parent document small. Store children in their own collection with a reference field and a compound index for efficient queries.
+
+```javascript
+// Parent stays lean
+{ _id: "user123", name: "Alice", activityCount: 48210, lastActivity: ISODate("...") }
+
+// Children in separate collection with efficient index
+// Index: { userId: 1, ts: -1 }
+{ userId: "user123", action: "login", ts: ISODate("...") }
+```
+
+For large binary blobs, use GridFS for in-database storage, or — often more efficient — store them in external object storage and keep only a reference in MongoDB.
+
+### Solution 2: split hot and cold fields (Subset Pattern)
+
+Keep frequently-accessed (hot) data in the main document; store rarely-accessed (cold) data in a separate collection. This dramatically improves cache density for hot-path queries.
+
+**Incorrect (all data in one document):** A movie document with all 10,000 reviews embedded (~1MB of cold data alongside ~1KB of hot data like title, rating, plot) means every page load pulls ~1MB into RAM. Most page views only need title + rating + plot, so this reduces how many movies fit in cache (e.g. 1GB RAM ≈ 1,000 movies instead of ~1,000,000 if only hot data were loaded).
+
+**Correct (subset pattern):** The movie document (~2KB) contains only hot fields: `title`, `year`, `rating`, `plot`, `reviewStats` (count, avgRating, distribution), and a bounded `featuredReviews` array (top 5 only, ~500 bytes). Full reviews live in a separate `reviews` collection with `movieId` reference, loaded only when the user clicks "Show all reviews."
+
+Similarly, a product document should keep only hot fields in the main document (~500 bytes): name, price, thumbnail URL, avgRating, reviewCount, inStock. Move cold data to separate collections — `products_details` (description, fullSpecs), `products_images` (images array), `products_reviews` (paginated reviews).
+
+**How to identify hot vs cold data:**
+
+| Hot Data (embed) | Cold Data (separate) |
+|------------------|----------------------|
+| Displayed on every page load | Only on user action (click, scroll) |
+| Used for filtering/sorting | Historical/archival |
+| Small relative size | Large relative size |
+| Bounded small subsets | Large or unbounded sets |
+| Changes rarely | Changes frequently |
+
+**Maintaining an embedded subset:**
+
+```javascript
+// When a new review is added:
+// 1. Insert full review into reviews collection
+db.reviews.insertOne({ movieId: "movie123", user: "newUser", rating: 5, text: "Amazing!", date: new Date(), helpful: 0 })
+
+// 2. Update movie stats
+db.movies.updateOne(
+  { _id: "movie123" },
+  { $inc: { "reviewStats.count": 1, "reviewStats.distribution.5": 1 } }
+)
+
+// 3. Periodically refresh featured reviews (background job)
+const topReviews = db.reviews.find({ movieId: "movie123" }).sort({ helpful: -1 }).limit(5).toArray()
+db.movies.updateOne({ _id: "movie123" }, { $set: { featuredReviews: topReviews } })
+```
+
+For arrays, atomic `$slice` keeps the embedded subset bounded without a background job:
+
+```javascript
+db.posts.updateOne(
+  { _id: "post123" },
+  {
+    $push: {
+      recentComments: {
+        $each: [newComment],
+        $slice: -20,
+        $sort: { ts: -1 }
+      }
+    },
+    $inc: { commentCount: 1 }
+  }
+)
+// Also insert into overflow comments collection
+db.comments.insertOne({ postId: "post123", ...newComment })
+```
+
+### Solution 3: projection (when you can't refactor)
+
+```javascript
+// Only transfers ~500 bytes instead of 665KB over the network
+db.products.find(
+  { category: "electronics" },
+  { name: 1, price: 1, thumbnail: 1 }
+)
+```
+
+Projection reduces network transfer but still loads full documents into memory unless the query is fully covered by an index. For real working-set reduction, split hot and cold data into separate collections.
+
+### Prevention strategies
+
+```javascript
+// 1. Schema validation with array limits
+db.createCollection("users", {
+  validator: {
+    $jsonSchema: {
+      properties: {
+        addresses: { maxItems: 10 },
+        tags: { maxItems: 100 }
+      }
+    }
+  }
+})
+// (See fundamental-schema-validation.md for full validation guidance).
+
+// 2. Application-level checks before write
+const doc = await db.users.findOne({ _id: userId })
+const currentSize = BSON.calculateObjectSize(doc)
+if (currentSize > 200 * 1024) {  // 200KB warning — well before trouble
+  logger.warn("Document size exceeding recommended threshold")
+}
+
+// 3. Use $slice to cap arrays
+db.users.updateOne(
+  { _id: userId },
+  {
+    $push: {
+      activityLog: {
+        $each: [newActivity],
+        $slice: -1000  // Keep only last 1000
+      }
+    }
+  }
+)
+```
+
+### Workload signals
+
+| Signal | Action |
+|--------|--------|
+| Array cardinality keeps growing | Cap with `$slice` or move to separate collection |
+| Array field is heavily indexed | Review multikey fan-out; move cold data out |
+| Reads only need recent subset | Embed recent N, reference full history |
+| Updates slow as array grows | Switch to referenced write path |
+| Documents routinely exceed ~200KB | Reassess schema — consider splitting hot/cold |
+| WiredTiger cache pressure is high | Check for bloated documents; split candidates |
+
+### When keeping data together is fine
+
+- **Small, bounded arrays** — tags (max 20), roles (max 5), addresses (max 10) with a hard limit.
+- **Write-once arrays** — built once and never modified; size still affects working set.
+- **Arrays of primitives** — `tags: ["a", "b", "c"]` is much cheaper than arrays of objects.
+- **Small collections that fit in RAM** — if your entire collection is <1GB, document size matters less.
+- **Always need all data** — if every access pattern truly needs the full document, splitting adds overhead.
+
+## Verify with
+
+```javascript
+// Find largest documents in collection
+db.collection.aggregate([
+  { $project: { size: { $bsonSize: "$$ROOT" } } },
+  { $sort: { size: -1 } },
+  { $limit: 10 }
+])
+
+// Check specific field sizes to find bloat
+db.collection.aggregate([
+  { $project: {
+    total: { $bsonSize: "$$ROOT" },
+    activitySize: { $bsonSize: { $ifNull: ["$activityLog", []] } },
+    profileSize: { $bsonSize: { $ifNull: ["$profile", {}] } }
+  }}
+])
+
+// Find documents with large arrays
+db.collection.aggregate([
+  { $project: {
+    size: { $bsonSize: "$$ROOT" },
+    arrayLen: { $size: { $ifNull: ["$myArray", []] } }
+  }},
+  { $match: { arrayLen: { $gt: 100 } } },
+  { $sort: { arrayLen: -1 } },
+  { $limit: 10 }
+])
+
+// Find documents with hot/cold imbalance
+db.collection.aggregate([
+  { $project: {
+    totalSize: { $bsonSize: "$$ROOT" },
+    coldSize: { $bsonSize: { $ifNull: ["$reviews", []] } },
+    hotSize: { $subtract: [
+      { $bsonSize: "$$ROOT" },
+      { $bsonSize: { $ifNull: ["$reviews", []] } }
+    ]}
+  }},
+  { $match: {
+    $expr: { $gt: ["$coldSize", { $multiply: ["$hotSize", 10] }] }
+  }},
+  { $limit: 10 }
+])
+
+// Check working set vs RAM
+db.serverStatus().wiredTiger.cache
+// "bytes currently in the cache" vs "maximum bytes configured"
+```
+
+Atlas Schema Suggestions flags: "Array field may grow without bound", "Document size exceeds recommended limit"
+
+References:
+- [BSON Document Size Limit](https://mongodb.com/docs/manual/reference/limits/#std-label-limit-bson-document-size)
+- [Avoid Unbounded Arrays](https://mongodb.com/docs/manual/data-modeling/design-antipatterns/unbounded-arrays/)
+- [Reduce Bloated Documents](https://mongodb.com/docs/manual/data-modeling/design-antipatterns/bloated-documents/)

--- a/.agents/skills/mongodb-schema-design/references/fundamental-embed-vs-reference.md
+++ b/.agents/skills/mongodb-schema-design/references/fundamental-embed-vs-reference.md
@@ -1,0 +1,418 @@
+---
+title: Embed vs Reference Decision Framework
+impact: HIGH
+impactDescription: "Determines long-term query and update paths in your application data model"
+tags: schema, embedding, referencing, relationships, fundamentals, one-to-one, one-to-few, one-to-many, many-to-many, tree, hierarchy
+---
+
+## Embed vs Reference Decision Framework
+
+**This is one of the most important schema decisions you'll make.** Choose embedding or referencing based on access patterns, not just entity relationships.
+
+**Embed when:**
+- Data is always accessed together (1:1 or 1:few relationships)
+- Child data doesn't make sense without parent
+- Updates to both happen atomically
+- Child array is clearly bounded by product constraints
+
+**Reference when:**
+- Data is accessed independently
+- Many-to-many relationships exist
+- Child data is large relative to the parent or array growth is unbounded
+- Different update frequencies
+
+**Decision Matrix:**
+
+| Relationship | Cardinality | Access Pattern | Bounded? | Decision |
+|--------------|-------------|----------------|----------|----------|
+| User → Profile | 1:1 | Always together | Yes | **Embed** |
+| User → Addresses | 1:few (1-5) | Usually together | Yes | **Embed array** |
+| Order → Line Items | 1:few (1-50) | Always together | Yes | **Embed array** |
+| Publisher → Books | 1:many (1000+) | Often separate | No | **Reference** |
+| Post → Comments | 1:many (unbounded) | Separate adds | No | **Reference** |
+| Students ↔ Classes | Many-to-many | Both directions | Moderate | **Reference both ways** |
+| Product ↔ Category | Many-to-many | Either way | Moderate | **Embed refs in primary direction** |
+
+---
+
+### One-to-One: embed in the parent document
+
+**Embed one-to-one related data directly in the parent when it is consistently co-accessed.** Keeping it in one document eliminates a round-trip and guarantees atomicity.
+
+**Incorrect (separate collections for 1:1 data):** Storing user accounts and profiles in separate collections when they are always accessed together requires two queries per lookup, two index lookups, and risks orphaned records.
+
+**Correct (embedded):**
+
+```javascript
+{
+  _id: "user123",
+  email: "alice@example.com",
+  createdAt: ISODate("2024-01-01"),
+  profile: {
+    name: "Alice Smith",
+    avatar: "https://cdn.example.com/alice.jpg",
+    bio: "Developer building cool things"
+  }
+}
+
+// Single query, atomic updates
+db.users.updateOne(
+  { _id: "user123" },
+  { $set: { "profile.name": "Alice Johnson" } }
+)
+```
+
+Use subdocuments to logically group related fields — e.g. `auth` (passwordHash, lastLogin), `profile` (name, avatar), `settings` (theme, notifications) — all 1:1 data, logically organized without separate collections.
+
+**Common 1:1 relationships to embed:** User/Profile, Country/Capital, Building/Address, Order/ShippingAddress, Product/Dimensions.
+
+**When NOT to embed 1:1:**
+- Data accessed independently (profile page separate from auth operations)
+- Different security requirements (auth vs profile)
+- Extreme size difference (embedded doc >10KB, parent <1KB)
+- Different update frequencies (profile hourly, auth rarely)
+
+---
+
+### One-to-Few: embed bounded arrays
+
+**Embed bounded, small arrays directly in the parent document.** When a parent has a limited number of children usually accessed together, embedding keeps data in one read path.
+
+**Incorrect (separate collection for few items):**
+
+```javascript
+// Addresses in separate collection — user typically has 1-3
+{ userId: "user123", type: "home", street: "123 Main", city: "Boston" }
+// Requires $lookup for ~2 addresses, orphan risk on user delete
+```
+
+**Correct (embedded array):**
+
+```javascript
+{
+  _id: "user123",
+  name: "Alice Smith",
+  addresses: [
+    { type: "home", street: "123 Main St", city: "Boston", state: "MA", zip: "02101" },
+    { type: "work", street: "456 Oak Ave", city: "Boston", state: "MA", zip: "02102" }
+  ]
+}
+
+// Add address atomically
+db.users.updateOne(
+  { _id: "user123" },
+  { $push: { addresses: { type: "vacation", street: "789 Beach", city: "Miami" } } }
+)
+
+// Update specific address
+db.users.updateOne(
+  { _id: "user123", "addresses.type": "home" },
+  { $set: { "addresses.$.city": "Cambridge" } }
+)
+```
+
+**Common one-to-few:** User/Addresses (1-5), User/PhoneNumbers (1-3), Product/Variants (3-10), Author/PenNames (1-3), Order/LineItems (1-50).
+
+**Enforce bounds with schema validation:**
+
+```javascript
+db.createCollection("users", {
+  validator: {
+    $jsonSchema: {
+      properties: {
+        addresses: {
+          bsonType: "array",
+          maxItems: 10,
+          items: {
+            bsonType: "object",
+            required: ["city"],
+            properties: {
+              type: { enum: ["home", "work", "billing", "shipping"] },
+              city: { bsonType: "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+})
+```
+
+(See fundamental-schema-validation.md for full validation guidance).
+
+**When NOT to embed arrays:**
+- Unbounded growth (comments, orders, events) — use separate collection
+- Independent access (addresses queried without user context)
+- Large child documents relative to parent
+- Steadily growing array size approaching unbounded behavior
+
+---
+
+### One-to-Many: reference in child documents
+
+**Use references when the "many" side is unbounded or frequently accessed independently.** Store the parent's ID in each child document with an index on that field.
+
+**Incorrect (embedding unbounded arrays):** Embedding all 10,000+ books inside a publisher document means adding one book rewrites the entire large document, eventually exceeding 16MB.
+
+**Correct (reference in children):**
+
+```javascript
+// Publisher stays small and fixed-size
+{ _id: "oreilly", name: "O'Reilly Media", founded: 1978, bookCount: 3500 }
+
+// Each book references publisher; index on { publisherId: 1 }
+{ _id: "book001", title: "New MongoDB Book", publisherId: "oreilly" }
+
+// Efficient indexed queries
+db.books.find({ publisherId: "oreilly" })
+
+// $lookup when you need details from both sides
+db.books.aggregate([
+  { $match: { publisherId: "oreilly" } },
+  { $lookup: {
+    from: "publishers",
+    localField: "publisherId",
+    foreignField: "_id",
+    as: "publisher"
+  }},
+  { $unwind: "$publisher" }
+])
+```
+
+**Hybrid with subset:** Embed a bounded subset (e.g. top 5 featured books with `_id`, `title`, `isbn`) in the publisher for display without `$lookup`. "View all books" queries the books collection.
+
+**Keep denormalized counts in sync:**
+
+```javascript
+db.books.insertOne({ title: "New Book", publisherId: "oreilly" })
+db.publishers.updateOne({ _id: "oreilly" }, { $inc: { bookCount: 1 } })
+```
+
+**When to reference:** Unbounded children (Publisher→Books), large child documents (User→Orders), independent queries (Department→Employees), different lifecycles (Author→Articles).
+
+**When NOT to reference:** Bounded small arrays (User's 3 addresses), always accessed together (Order→LineItems), never queried without parent.
+
+---
+
+### Many-to-Many: choose a primary query direction
+
+**Many-to-many relationships require choosing a primary query direction.** Unlike SQL's join tables, MongoDB favors denormalization toward your most common query pattern.
+
+**Incorrect (SQL-style junction table):**
+
+```javascript
+// 3 collections, always need joins
+// students: { _id, name }  /  classes: { _id, name }  /  enrollments: { studentId, classId }
+// Every query requires aggregation with $lookup
+```
+
+**Correct (embed in primary query direction):**
+
+Embed references on the side you query most. If you primarily query "which classes is this student in," embed class summaries in the student. For the reverse, embed student summaries in the class.
+
+**Bidirectional embedding (when both directions are common):**
+
+```javascript
+// Book with author summaries
+{
+  _id: "book001",
+  title: "Cell Biology",
+  authors: [
+    { authorId: "author124", name: "Ellie Smith" },
+    { authorId: "author381", name: "John Palmer" }
+  ]
+}
+
+// Author with book summaries
+{
+  _id: "author124",
+  name: "Ellie Smith",
+  books: [
+    { bookId: "book001", title: "Cell Biology" },
+    { bookId: "book042", title: "Molecular Biology" }
+  ]
+}
+// Trade-off: data duplication, but fast queries in both directions
+```
+
+**Reference-only (for large cardinality):**
+
+```javascript
+// Product stores category IDs (small array per product)
+{ _id: "prod123", name: "Laptop", categoryIds: ["cat1", "cat2", "cat3"] }
+// Category has no back-reference array (avoid huge arrays)
+{ _id: "cat1", name: "Electronics" }
+// Products in a category: db.products.find({ categoryIds: "cat1" })
+```
+
+**Choosing strategy:**
+
+| Query Pattern | Cardinality | Strategy |
+|---------------|-------------|----------|
+| Students → Classes | Few classes per student | Embed in student |
+| Classes → Students | Many students per class | Reference only |
+| Both directions common | Moderate both sides | Bidirectional embed |
+| High cardinality both | Large/growing both sides | Reference-only + `$lookup` |
+
+**Maintaining bidirectional data — use transactions for atomicity:**
+
+```javascript
+const session = client.startSession()
+session.withTransaction(async () => {
+  await db.students.updateOne(
+    { _id: "student1" },
+    { $push: { classes: { classId: "class101", name: "Database Systems" } } },
+    { session }
+  )
+  await db.classes.updateOne(
+    { _id: "class101" },
+    { $push: { students: { studentId: "student1", name: "Alice Smith" } } },
+    { session }
+  )
+})
+```
+
+---
+
+### Tree and hierarchical data
+
+**Hierarchical data requires choosing a tree pattern based on your primary operations.** MongoDB offers multiple patterns, each with different tradeoffs.
+
+**Common hierarchical data:** Category trees, org charts, file/folder structures, comment threads, geographic hierarchies.
+
+#### Pattern 1: Parent References
+
+**Best for:** Finding parent, updating parent, simple child listing.
+
+```javascript
+{ _id: "MongoDB", parent: "Databases" }
+{ _id: "Databases", parent: "Programming" }
+{ _id: "Programming", parent: null }
+
+db.categories.createIndex({ parent: 1 })
+db.categories.find({ parent: "Databases" })  // immediate children
+```
+
+Con: Finding all descendants requires recursive queries or `$graphLookup`.
+
+#### Pattern 2: Child References
+
+**Best for:** Finding children, graph-like structures.
+
+```javascript
+{ _id: "Databases", children: ["MongoDB", "PostgreSQL", "MySQL"] }
+```
+
+Con: Finding ancestors requires recursion; array updates on every child add/remove.
+
+#### Pattern 3: Array of Ancestors
+
+**Best for:** Breadcrumb navigation, ancestor and descendant lookups.
+
+```javascript
+{ _id: "MongoDB", parent: "Databases", ancestors: ["Programming", "Databases"] }
+{ _id: "Atlas", parent: "MongoDB", ancestors: ["Programming", "Databases", "MongoDB"] }
+
+db.categories.createIndex({ ancestors: 1 })
+db.categories.find({ ancestors: "Databases" })  // all descendants
+```
+
+Including a `parent` field enables `$graphLookup` traversal without application-side recursion.
+
+#### Pattern 4: Materialized Paths
+
+**Best for:** Subtree queries, regex-based lookups, hierarchy sorting.
+
+```javascript
+{ _id: "MongoDB", path: ",Programming,Databases,MongoDB," }
+{ _id: "Atlas", path: ",Programming,Databases,MongoDB,Atlas," }
+
+db.categories.createIndex({ path: 1 })
+db.categories.find({ path: /^,Programming,Databases,MongoDB,/ })  // all descendants
+db.categories.find({}).sort({ path: 1 })  // hierarchy display order
+```
+
+#### Tree pattern comparison
+
+| Pattern | Parent | Children | Descendants | Ancestors | Update Cost |
+|---------|--------|----------|-------------|-----------|-------------|
+| Parent Refs | Direct | Indexed | Recursive/`$graphLookup` | Recursive | Low |
+| Child Refs | Membership query | Direct | Recursive/`$graphLookup` | Recursive | Low–moderate |
+| Array of Ancestors | Via `parent` | Via `parent` | Fast (indexed) | Direct (stored) | Moderate |
+| Materialized Paths | Via path/`parent` | Prefix query | Regex/prefix | From stored path | Moderate |
+
+**Recommended by use case:** Category breadcrumbs → Array of Ancestors. File browser → Parent References. Org chart reporting → Materialized Paths. Comment threads → Parent References.
+
+---
+
+### When NOT to embed (summary)
+
+- **Unbounded growth**: Comments, logs, events — separate collection.
+- **Large child documents**: If each child is large relative to the parent, references are usually safer.
+- **Independent access**: If you ever query child without parent, reference.
+- **Different lifecycles**: If child data is archived/deleted separately.
+- **Graph-like data**: Multiple parents → use `$graphLookup` or a graph database.
+
+## Verify with
+
+```javascript
+// Check document sizes for embedded collections
+db.collection.aggregate([
+  { $project: {
+    size: { $bsonSize: "$$ROOT" },
+    arrayLen: { $size: { $ifNull: ["$items", []] } }
+  }},
+  { $match: { size: { $gt: 1000000 } } }
+])
+// Large documents may indicate embedding that should be referencing
+
+// Check embedded array sizes (one-to-few validation)
+db.users.aggregate([
+  { $project: { addressCount: { $size: { $ifNull: ["$addresses", []] } } } },
+  { $group: { _id: null, avg: { $avg: "$addressCount" }, max: { $max: "$addressCount" } } }
+])
+// If max keeps growing, consider a separate collection
+
+// Check for orphaned references (1:1 that should be embedded)
+db.profiles.aggregate([
+  { $lookup: { from: "users", localField: "userId", foreignField: "_id", as: "user" } },
+  { $match: { user: { $size: 0 } } }
+])
+// Orphans suggest 1:1 data should be embedded
+
+// Check for missing indexes on reference fields
+db.books.getIndexes()
+// Must have index on publisherId for efficient child lookups
+
+// Verify bidirectional many-to-many consistency
+db.students.aggregate([
+  { $unwind: "$classes" },
+  { $lookup: {
+    from: "classes",
+    let: { sid: "$_id", cid: "$classes.classId" },
+    pipeline: [
+      { $match: { $expr: { $eq: ["$_id", "$$cid"] } } },
+      { $match: { $expr: { $in: ["$$sid", "$students.studentId"] } } }
+    ],
+    as: "match"
+  }},
+  { $match: { match: { $size: 0 } } }
+])
+// Mismatches indicate inconsistent bidirectional data
+
+// Check tree consistency (no orphaned nodes)
+db.categories.aggregate([
+  { $match: { parent: { $ne: null } } },
+  { $lookup: { from: "categories", localField: "parent", foreignField: "_id", as: "parentDoc" } },
+  { $match: { parentDoc: { $size: 0 } } },
+  { $count: "orphanedNodes" }
+])
+```
+
+References:
+- [Embedding vs Referencing](https://mongodb.com/docs/manual/data-modeling/concepts/embedding-vs-references/)
+- [Model One-to-One Relationships](https://mongodb.com/docs/manual/tutorial/model-embedded-one-to-one-relationships-between-documents/)
+- [Model One-to-Many Relationships with Embedded Documents](https://mongodb.com/docs/manual/tutorial/model-embedded-one-to-many-relationships-between-documents/)
+- [Model One-to-Many Relationships with References](https://mongodb.com/docs/manual/tutorial/model-referenced-one-to-many-relationships-between-documents/)
+- [Model Many-to-Many Relationships](https://mongodb.com/docs/manual/tutorial/model-embedded-many-to-many-relationships-between-documents/)
+- [Model Tree Structures](https://mongodb.com/docs/manual/applications/data-models-tree-structures/)

--- a/.agents/skills/mongodb-schema-design/references/fundamental-schema-validation.md
+++ b/.agents/skills/mongodb-schema-design/references/fundamental-schema-validation.md
@@ -1,0 +1,131 @@
+---
+title: Use Schema Validation
+impact: MEDIUM
+impactDescription: "Prevents invalid data at database level, catches bugs before production corruption"
+tags: schema, validation, json-schema, data-integrity, fundamentals
+---
+
+## Use Schema Validation
+
+**Enforce document structure with MongoDB's built-in JSON Schema validation.** Catch invalid data before it corrupts your database, not after you've shipped 10,000 malformed documents to production. Schema validation is your last line of defense when application bugs slip through.
+
+**Incorrect (no validation):**
+
+Without validation, any document shape is accepted: an `email` field can contain a non-email string, an `age` field can hold a string instead of a number, and required fields like `email` can be omitted entirely. These invalid documents are discovered only when downstream consumers crash or return wrong data — often months later.
+
+**Correct (schema validation):**
+
+```javascript
+// Create collection with validation rules
+db.createCollection("users", {
+  validator: {
+    $jsonSchema: {
+      bsonType: "object",
+      required: ["email", "name"],
+      properties: {
+        email: {
+          bsonType: "string",
+          pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+          description: "must be a valid email address"
+        },
+        name: {
+          bsonType: "string",
+          minLength: 1,
+          maxLength: 100,
+          description: "must be 1-100 characters"
+        },
+        age: {
+          bsonType: "int",
+          minimum: 0,
+          maximum: 150,
+          description: "must be integer 0-150"
+        },
+        status: {
+          enum: ["active", "inactive", "pending"],
+          description: "must be one of: active, inactive, pending"
+        },
+        addresses: {
+          bsonType: "array",
+          maxItems: 10,  // Prevent unbounded arrays
+          items: {
+            bsonType: "object",
+            required: ["city"],
+            properties: {
+              street: { bsonType: "string" },
+              city: { bsonType: "string" },
+              zip: { bsonType: "string", pattern: "^[0-9]{5}$" }
+            }
+          }
+        }
+      }
+    }
+  },
+  validationLevel: "strict",
+  validationAction: "error"
+})
+
+// Invalid inserts now fail immediately with clear error
+db.users.insertOne({ email: "not-an-email" })
+// Error: Document failed validation:
+// "email" does not match pattern, "name" is required
+```
+
+**Validation levels and actions:**
+
+| validationLevel | Behavior |
+|-----------------|----------|
+| `strict` | Validate ALL inserts and updates (default, recommended) |
+| `moderate` | Only validate documents that already match schema |
+
+| validationAction | Behavior |
+|------------------|----------|
+| `error` | Reject invalid documents (default, recommended) |
+| `warn` | Allow but log warning (use during migration only) |
+
+**Add validation to existing collection:**
+
+```javascript
+// Start with moderate + warn to discover violations
+db.runCommand({
+  collMod: "users",
+  validator: { $jsonSchema: {...} },
+  validationLevel: "moderate",  // Don't break existing invalid docs
+  validationAction: "warn"       // Log violations, don't block
+})
+
+// Check for violations using the actual validator shape
+const info = db.getCollectionInfos({ name: "users" })[0]
+const validator = info?.options?.validator
+db.users.find({ $nor: [validator] })
+
+// Then switch to strict + error
+db.runCommand({
+  collMod: "users",
+  validationLevel: "strict",
+  validationAction: "error"
+})
+```
+
+**When NOT to use this pattern:**
+
+- **Rapid prototyping**: Skip validation during early development, add before production.
+- **Schema-per-document designs**: Some collections intentionally store varied document shapes.
+- **Log/event collections**: High-write collections where validation overhead matters.
+
+## Verify with
+
+```javascript
+// Read current validator and validation settings
+const info = db.getCollectionInfos({ name: "users" })[0]
+printjson({
+  validationLevel: info?.options?.validationLevel,
+  validationAction: info?.options?.validationAction,
+  validator: info?.options?.validator
+})
+
+// Primary compliance check: find documents that do NOT match validator
+const validator = info?.options?.validator
+db.users.find({ $nor: [validator] })
+```
+
+Reference: [Schema Validation](https://mongodb.com/docs/manual/core/schema-validation/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-approximation.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-approximation.md
@@ -1,0 +1,80 @@
+---
+title: "Approximation Pattern"
+impact: MEDIUM
+impactDescription: "Reduces write load by storing approximate values when exact real-time counts are not required"
+tags: schema, patterns, approximation, computed, write-optimization
+---
+
+## Approximation Pattern
+
+**Intentionally store approximate values to reduce write load when exact real-time counts are not required.** High-frequency counters (page views, trending scores, social media counters) that increment by +1 per event can create expensive per-event writes. The approximation pattern batches these increments, trading staleness for dramatically lower write volume.
+
+**Incorrect (write to database on every event):**
+
+```javascript
+// Page view counter - writes to MongoDB on every single view
+function recordPageView(articleId) {
+  db.articles.updateOne(
+    { _id: articleId },
+    {
+      $inc: { viewCount: 1 },
+      $set: { lastViewedAt: new Date() }
+    }
+  )
+}
+// 1M page views/day = 1M database writes/day
+// High write load for a counter that doesn't need real-time accuracy
+```
+
+**Correct (batch writes with threshold):**
+
+The document stores an approximate count plus a sync timestamp. The application tracks counts in local memory (e.g. a `Map` keyed by article ID) and writes to the database only when the local counter crosses a threshold (e.g. every 100 views). At threshold=100 this yields ~100× fewer database writes.
+
+The document includes `viewCount` (approximate — may lag by up to one threshold) and `lastSyncedAt`. When the local counter reaches the threshold, the application issues a single `$inc` by the threshold amount and updates `lastSyncedAt`. Unsynced local increments are lost on application restart.
+
+**Tradeoffs:**
+
+| Concern | Impact |
+|---------|--------|
+| Write reduction | ~100x fewer DB writes (at threshold=100) |
+| Staleness | Up to `threshold` events behind |
+| Accuracy | Approximate — never exact real-time |
+| Crash safety | Unsynced local increments lost on restart |
+
+**Difference from Computed Pattern:**
+
+- **Computed Pattern**: pre-computes expensive aggregations, stores exact results
+- **Approximation Pattern**: intentionally stores inexact values to reduce write frequency
+
+Use Approximation when staleness is acceptable. Use Computed when exact values are needed but recalculating each time is too expensive.
+
+**When NOT to use this pattern:**
+
+- **Financial amounts, inventory counts**: Exact values required — approximation is unacceptable.
+- **Low-frequency updates**: If counter changes rarely, approximation adds complexity without benefit.
+- **Regulatory/audit requirements**: When exact counts are mandated.
+
+## Verify with
+
+### Check write frequency on counter fields
+
+Use codebase if available, ask the user.
+
+High count relative to read count on a specific field suggests approximation would help
+
+```javascript
+// Compare counter staleness
+db.articles.aggregate([
+  { $sort: { lastSyncedAt: 1 } },
+  { $limit: 10 },
+  { $project: {
+    title: 1,
+    viewCount: 1,
+    lastSyncedAt: 1,
+    staleness: { $subtract: ["$$NOW", "$lastSyncedAt"] }
+  }}
+])
+// Verify staleness is within acceptable bounds for your use case
+```
+
+Reference: [Use the Approximation Pattern](https://mongodb.com/docs/manual/data-modeling/design-patterns/computed-values/approximation-schema-pattern/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-archive.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-archive.md
@@ -1,0 +1,143 @@
+---
+title: Use Archive Pattern for Historical Data
+impact: MEDIUM
+impactDescription: "Reduces active collection size, improves query performance, lowers storage costs"
+tags: schema, patterns, archive, data-lifecycle, merge, ttl, online-archive
+---
+
+## Use Archive Pattern for Historical Data
+
+**Storing old data alongside recent data degrades performance.** As collections grow with historical data that's rarely accessed, queries slow down, indexes bloat, and working set exceeds RAM. The archive pattern moves old data to separate storage while keeping your active collection fast.
+
+**Incorrect (all data in one collection):**
+
+A sales collection with 5 years of data (50M documents) where only the recent 6 months are actively queried suffers from: indexes covering the full 50M documents when only ~1M are relevant, working set including old data pages, backups including rarely-accessed history, and hot-tier storage costs for data that could be cold.
+
+**Correct (archive old data separately):**
+
+```javascript
+// Step 1: Define archive threshold (older than 6 months)
+const sixMonthsAgo = new Date()
+sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
+
+// Step 2: Move old data to archive collection using $merge
+db.sales.aggregate([
+  { $match: { date: { $lt: sixMonthsAgo } } },
+  { $merge: {
+      into: "sales_archive",
+      on: "_id",
+      whenMatched: "keepExisting",  // Don't overwrite if re-run
+      whenNotMatched: "insert"
+    }
+  }
+])
+
+// Step 3: Delete archived data from active collection
+db.sales.deleteMany({ date: { $lt: sixMonthsAgo } })
+
+// Result:
+// - sales: Recent data, fast queries, small indexes
+// - sales_archive: Historical data, rarely queried
+```
+
+**Archive storage options (best to worst for cost/performance):**
+
+1. **External file storage (S3, cloud object storage)** — Best for compliance and long-term retention at lowest cost. Export to JSON/BSON, store in S3, query via Atlas Data Federation when needed.
+2. **Separate, cheaper cluster** — Best for occasional historical queries. Replicate to a lower-tier Atlas cluster at reduced cost.
+3. **Separate collection on same cluster** — Best for simple implementation with frequent historical access. As shown above with `sales_archive`, but still uses the same storage tier.
+4. **Atlas Online Archive (Atlas only)** — MongoDB manages automatic movement to cloud object storage; query via Federated Database Instance.
+
+**Design tips for archivable schemas:**
+
+```javascript
+// TIP 1: Use embedded data model for archives
+// Archived data must be self-contained
+
+// BAD: References that may be deleted
+{
+  _id: "order123",
+  customerId: "cust456",  // Customer may be deleted
+  productIds: ["prod1", "prod2"]  // Products may change
+}
+
+// GOOD: Embedded snapshot of related data
+{
+  _id: "order123",
+  customer: {
+    _id: "cust456",
+    name: "Jane Doe",
+    email: "jane@example.com"
+  },
+  products: [
+    { _id: "prod1", name: "Widget", price: 29.99 },
+    { _id: "prod2", name: "Gadget", price: 49.99 }
+  ],
+  date: ISODate("2020-01-15")
+}
+
+// TIP 2: Store age in a single, indexable field
+// Makes archive queries efficient
+{
+  date: ISODate("2020-01-15"),  // Single field for age
+  // NOT: { year: 2020, month: 1, day: 15 }
+}
+
+// TIP 3: Handle "never expire" documents
+{
+  date: ISODate("2025-01-15"),
+  retentionPolicy: "permanent"  // Or use far-future date
+}
+
+// Archive query excludes permanent records:
+db.sales.aggregate([
+  { $match: {
+      date: { $lt: fiveYearsAgo },
+      retentionPolicy: { $ne: "permanent" }
+    }
+  },
+  { $merge: { into: "sales_archive" } }
+])
+```
+
+**Automated archival with scheduling:**
+
+Create a script (run via cron, Atlas Triggers, or an application scheduler) that:
+
+1. Counts documents older than the cutoff date (excluding those with `retentionPolicy: "permanent"`).
+2. Processes in batches (e.g. 10,000 IDs at a time) to avoid long-running operations: fetch a batch of `_id` values, pipe them through an aggregation with `$match` and `$merge` into the archive collection, then `deleteMany` the batch from the active collection.
+3. Logs progress after each batch.
+
+This reuses the same `$merge`-based archival shown above but throttles work to avoid overloading the cluster.
+
+**Atlas Online Archive (Atlas only):**
+
+Atlas Online Archive automatically tiers data to MongoDB-managed cloud object storage based on a date-field rule (e.g. archive after 365 days). Archived data is queried transparently via a Federated Database Instance — slightly slower but much cheaper. No application code changes are required.
+
+**When NOT to use archive pattern:**
+
+- **Small datasets**: If total data fits comfortably in RAM, archiving adds complexity without benefit.
+- **Uniform access patterns**: If old and new data are queried equally.
+- **Compliance requires instant access**: If regulations require sub-second queries on all historical data.
+- **Already using TTL**: If data should be deleted, not archived, use TTL indexes.
+
+## Verify with
+
+```javascript
+// Analyze archive candidates
+const cutoff = new Date()
+cutoff.setFullYear(cutoff.getFullYear() - 5)
+
+db.sales.aggregate([
+  { $facet: {
+      total: [{ $count: "count" }],
+      old: [
+        { $match: { date: { $lt: cutoff } } },
+        { $count: "count" }
+      ]
+    }
+  }
+])
+// If old documents are >30% of total, archiving can improve performance
+```
+
+Reference: [Archive Pattern](https://mongodb.com/docs/manual/data-modeling/design-patterns/archive/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-attribute.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-attribute.md
@@ -1,0 +1,77 @@
+---
+title: Use Attribute Pattern for Sparse or Variable Fields
+impact: MEDIUM
+impactDescription: "Reduces sparse indexes and enables efficient search across many optional fields"
+tags: schema, patterns, attribute, sparse-fields, indexing, flexible-schema
+---
+
+## Use Attribute Pattern for Sparse or Variable Fields
+
+**If documents have many optional fields, move them into a key-value array.** This avoids dozens of sparse indexes and lets you query across attributes with a single multikey index.
+
+**Incorrect (separate field and index per optional attribute):**
+
+```javascript
+// Many optional fields - most are missing on any given document
+{
+  _id: 1,
+  name: "Bottle",
+  color: "red",
+  size: "M",
+  material: "glass",
+  // 20+ other optional fields, varying per document
+}
+
+// One partial index per optional field — correct use of partialFilterExpression,
+// but you end up maintaining dozens of indexes as attributes grow
+db.items.createIndex({ color: 1 }, { partialFilterExpression: { color: { $exists: true } } })
+db.items.createIndex({ size: 1 }, { partialFilterExpression: { size: { $exists: true } } })
+db.items.createIndex({ material: 1 }, { partialFilterExpression: { material: { $exists: true } } })
+// … repeated for every new attribute
+```
+
+**Correct (attribute pattern):**
+
+```javascript
+// Store optional fields as key-value pairs
+{
+  _id: 1,
+  name: "Bottle",
+  attributes: [
+    { k: "color", v: "red" },
+    { k: "size", v: "M" },
+    { k: "material", v: "glass" }
+  ]
+}
+
+// Single multikey index for all attributes
+
+db.items.createIndex({ "attributes.k": 1, "attributes.v": 1 })
+
+// Query for color = red
+
+db.items.find({
+  attributes: { $elemMatch: { k: "color", v: "red" } }
+})
+```
+
+**When NOT to use this pattern:**
+
+- **Fixed schema**: If fields are stable and always present.
+- **Type-specific validation**: If each field needs strict schema rules.
+- **Single-field queries only**: A normal field may be simpler and faster.
+- **Atlas Search workloads**: The `{ k, v }` key-value structure cannot be mapped as
+  named fields in Atlas Search indexes. If you need full-text search on attribute
+  values by key name, use static named fields instead.
+
+## Verify with
+
+```javascript
+// Ensure queries use the multikey index
+
+db.items.find({
+  attributes: { $elemMatch: { k: "material", v: "glass" } }
+}).explain("executionStats")
+```
+
+Reference: [Attribute Pattern](https://mongodb.com/docs/manual/data-modeling/design-patterns/group-data/attribute-pattern/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-bucket.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-bucket.md
@@ -1,0 +1,102 @@
+---
+title: Use Bucket Pattern to Group Related Data
+impact: MEDIUM
+impactDescription: "Reduces document count and can align storage with application access patterns like pagination"
+tags: schema, patterns, bucket, grouping, pagination, arrays
+---
+
+## Use Bucket Pattern to Group Related Data
+
+**Group a series of related items into bounded arrays within a single document.** The bucket pattern separates long series of data into distinct objects, reducing document count and aligning storage with how data is actually consumed. This is especially useful when an application accesses data in fixed-size groups (e.g. pages).
+
+> **For time-series data**, prefer [Time Series Collections](https://www.mongodb.com/docs/manual/core/timeseries-collections/), which apply bucketing automatically with built-in compression and indexing optimizations.
+
+**Incorrect (one document per event):**
+
+Storing one document per stock trade (e.g. `{ ticker, customerId, type, quantity, date }`) means the application pages through trades using skip/limit, which degrades as offset grows. Each trade is a separate document and index entry.
+
+**Correct (bucket pattern - group by customer, bounded per page):**
+
+Each document holds up to N trades for one customer (e.g. 10 trades = one page). The `_id` encodes customer ID and the first trade’s epoch seconds (e.g. `"123_1698349623"`), with a `count` field and a `history` array of trade objects. One bucket equals one page of data — a regex on `_id` uses the default `_id` index with no extra index needed, and document count drops by up to the bucket-size factor.
+
+**Insert with atomic upsert:**
+
+```javascript
+// Insert a new trade into the correct bucket
+db.trades.findOneAndUpdate(
+  {
+    "_id": /^123_/,            // Match buckets for this customer
+    "count": { $lt: 10 }       // Only if bucket isn't full
+  },
+  {
+    $push: {
+      history: {
+        type: "buy",
+        ticker: "MSFT",
+        qty: 42,
+        date: ISODate("2023-11-02T11:43:10Z")
+      }
+    },
+    $inc: { count: 1 },
+    $setOnInsert: {
+      _id: "123_1698939791",   // New bucket ID if upsert fires
+      customerId: 123
+    }
+  },
+  { upsert: true, sort: { _id: -1 } }
+)
+// If a bucket with room exists, the trade is pushed into it
+// Otherwise a new bucket document is created
+// Array is bounded — never exceeds 10 elements
+```
+
+**Query patterns:**
+
+```javascript
+// Page 1 of trades for customer 123
+db.trades.find({ _id: /^123_/ }).sort({ _id: 1 }).limit(1)
+
+// Page N (e.g. page 10)
+db.trades.find({ _id: /^123_/ }).sort({ _id: 1 }).skip(9).limit(1)
+
+// Each returned document IS a page — no per-trade skip/limit needed
+```
+
+**Choosing bucket boundaries:**
+
+| Bucketing Strategy | Good For | Example |
+|-------------------|----------|---------|
+| Fixed count (N items) | Pagination, evenly-sized pages | 10 trades per bucket |
+| Time window | Log/event grouping (when not using Time Series Collections) | 1 hour of events per bucket |
+| Logical grouping | Domain-driven partitioning | All line items in one order |
+
+**When NOT to use this pattern:**
+
+- **Time-series workloads**: Use [Time Series Collections](https://www.mongodb.com/docs/manual/core/timeseries-collections/) instead — they handle bucketing, compression, and indexing automatically.
+- **Random single-item access**: If you frequently query individual items by their own ID, buckets add unnecessary indirection.
+- **Low volume**: If the total series per entity is small, the added complexity isn't worth it.
+- **Highly variable item sizes**: Bucketing works best when items are roughly uniform in size so bucket documents stay predictable.
+
+## Verify with
+
+```javascript
+// Check that bucket size matches expectations
+db.trades.aggregate([
+  { $group: {
+    _id: null,
+    avgCount: { $avg: "$count" },
+    maxCount: { $max: "$count" },
+    totalBuckets: { $sum: 1 }
+  }}
+])
+// avgCount should approach your target bucket size
+// maxCount should not exceed it
+
+// Check average document size
+db.trades.aggregate([
+  { $project: { size: { $bsonSize: "$$ROOT" } } },
+  { $group: { _id: null, avgSize: { $avg: "$size" } } }
+])
+```
+
+Reference: [Group Data with the Bucket Pattern](https://www.mongodb.com/docs/manual/data-modeling/design-patterns/group-data/bucket-pattern/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-computed.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-computed.md
@@ -1,0 +1,162 @@
+---
+title: Use Computed Pattern for Expensive Calculations
+impact: MEDIUM
+impactDescription: "Improves read latency by pre-computing frequently-requested aggregations"
+tags: schema, patterns, computed, aggregation, performance, denormalization
+---
+
+## Use Computed Pattern for Expensive Calculations
+
+**Pre-calculate and store frequently-accessed computed values.** If you're running the same aggregation on every page load, you're wasting CPU cycles. Store the result in the document and update it on write or via background job—trades write complexity for read speed.
+
+**Incorrect (calculate on every read):**
+
+```javascript
+// Movie with all screenings in separate collection
+{ _id: "movie1", title: "The Matrix" }
+
+// Screenings collection - thousands of records
+{ movieId: "movie1", date: ISODate("..."), viewers: 344, revenue: 3440 }
+{ movieId: "movie1", date: ISODate("..."), viewers: 256, revenue: 2560 }
+// ... 10,000 screenings
+
+// Movie page aggregates every time
+db.screenings.aggregate([
+  { $match: { movieId: "movie1" } },
+  { $group: {
+    _id: "$movieId",
+    totalViewers: { $sum: "$viewers" },
+    totalRevenue: { $sum: "$revenue" },
+    screeningCount: { $sum: 1 }
+  }}
+])
+// Repeated scans can add substantial read latency and CPU overhead
+// 1M page views/day = 1M expensive aggregations
+```
+
+**Correct (pre-computed values):**
+
+Store computed stats directly in the movie document: `stats.totalViewers`, `stats.totalRevenue`, `stats.screeningCount`, `stats.avgViewersPerScreening`, and `stats.computedAt`. The movie page reads a single document with no aggregation needed on the hot path.
+
+**Update strategies:**
+
+```javascript
+// Strategy 1: Update on write (low write volume)
+// When new screening is added
+db.screenings.insertOne({
+  movieId: "movie1",
+  viewers: 400,
+  revenue: 4000
+})
+
+// Immediately update computed values
+db.movies.updateOne(
+  { _id: "movie1" },
+  {
+    $inc: {
+      "stats.totalViewers": 400,
+      "stats.totalRevenue": 4000,
+      "stats.screeningCount": 1
+    },
+    $set: { "stats.computedAt": new Date() }
+  }
+)
+
+// Strategy 2: Background job (high write volume)
+// Run hourly/daily aggregation job
+db.screenings.aggregate([
+  { $group: {
+    _id: "$movieId",
+    totalViewers: { $sum: "$viewers" },
+    totalRevenue: { $sum: "$revenue" },
+    count: { $sum: 1 }
+  }},
+  { $merge: {
+    into: "movies",
+    on: "_id",
+    whenMatched: [{
+      $set: {
+        "stats.totalViewers": "$$new.totalViewers",
+        "stats.totalRevenue": "$$new.totalRevenue",
+        "stats.screeningCount": "$$new.count",
+        "stats.computedAt": "$$NOW"
+      }
+    }]
+  }}
+])
+```
+
+**Common computed values:**
+
+| Source Data | Computed Value | Update Strategy |
+|-------------|----------------|-----------------|
+| Order line items | Order total | On write (single doc) |
+| Product reviews | Avg rating, review count | Background job |
+| User activity | Engagement score | Background job |
+| Transaction history | Account balance | On write |
+| Page views | View count, trending score | Batched updates |
+
+**Handling staleness:**
+
+Include a `computedAt` timestamp alongside the stats. Application code compares this timestamp against a freshness threshold (e.g. one hour) and triggers a refresh if the values are stale. Alternatively, surface the timestamp to users (e.g. “1,840,000 viewers — updated 1 hour ago”).
+
+**Windowed computations:**
+
+```javascript
+// Compute for time windows (rolling 30 days)
+{
+  _id: "movie1",
+  stats: {
+    allTime: { viewers: 1840000, revenue: 25880000 },
+    last30Days: { viewers: 45000, revenue: 630000 },
+    last7Days: { viewers: 12000, revenue: 168000 }
+  }
+}
+
+// Background job updates rolling windows
+db.screenings.aggregate([
+  { $match: {
+    movieId: "movie1",
+    date: { $gte: thirtyDaysAgo }
+  }},
+  { $group: {
+    _id: null,
+    viewers: { $sum: "$viewers" },
+    revenue: { $sum: "$revenue" }
+  }}
+])
+// Then update movie.stats.last30Days
+```
+
+**Consider on-demand materialized views:**
+
+When the computed results are best stored in a separate collection rather than embedded in the source documents, MongoDB's [on-demand materialized views](https://www.mongodb.com/docs/manual/core/materialized-views/) formalize this approach. An on-demand materialized view is an aggregation pipeline whose output is written to a separate collection using `$merge` or `$out`—the same mechanism shown in Strategy 2 above. The difference is conceptual: instead of updating a field on existing documents, you maintain a dedicated read-optimized collection that can be independently indexed. This is especially useful when:
+
+- The computed data has a different shape or granularity than the source (e.g. monthly summaries from daily records).
+- Multiple consumers need the pre-aggregated data, and a shared collection is cleaner than duplicating fields across documents.
+- You want to index the computed results independently of the source collection.
+
+On-demand materialized views are not automatically refreshed—you control when to re-run the pipeline, which gives you the same staleness trade-offs described above.
+
+**When NOT to use this pattern:**
+
+- **Rarely accessed calculations**: If stat is viewed once/day, compute on demand.
+- **High write frequency**: If source data changes every second, update overhead may exceed read savings.
+- **Complex multi-collection joins**: Some computations are too complex to maintain incrementally.
+- **Strong consistency required**: Computed values may be slightly stale.
+
+## Verify with
+
+### Find expensive aggregations that should be pre-computed
+
+For Atlas M10+ use slow query logs to find the slowest aggregations. See [Slow query logs](references/source-slow-query-logs.md). 
+Use codebase if available, ask the user.
+
+### Check if same aggregation runs repeatedly
+
+For Atlas M10+ use $queryStats. See [Query Stats](references/source-query-stats.md)
+Use codebase if available, ask the user.
+
+High count + high avgMs on an aggregation that computes a result = candidate for computed pattern
+
+Reference: [Computed Schema Pattern](https://mongodb.com/docs/manual/data-modeling/design-patterns/computed-values/computed-schema-pattern/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-document-versioning.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-document-versioning.md
@@ -1,0 +1,166 @@
+---
+title: "Document Versioning Pattern"
+impact: MEDIUM
+impactDescription: "Enables reproducing exact historical document state for audit, compliance, and rollback"
+tags: schema, patterns, versioning, audit, compliance
+---
+
+## Document Versioning Pattern
+
+**Store full document history in a separate `revisions` collection to enable reproducing historical state.** This is different from schema versioning (which handles field migration)—document versioning stores complete snapshots of each change. Use it for insurance policies, legal documents, compliance audit trails, and any data where you must reproduce exact historical state.
+
+**Incorrect (overwrite history with no trail):**
+
+```javascript
+// Policy document — only current state exists
+{
+  _id: "POL-001",
+  holder: "Jane Smith",
+  premium: 450,
+  coverage: "comprehensive",
+  updatedAt: ISODate("2024-06-01")
+}
+
+// When premium changes, old value is lost forever
+db.policies.updateOne(
+  { _id: "POL-001" },
+  { $set: { premium: 475, updatedAt: new Date() } }
+)
+// Previous premium of 450 is gone — no audit trail
+// Cannot reproduce what the policy looked like on 2024-03-15
+// Compliance audit fails: "show me the policy as of Q1"
+```
+
+**Correct (current collection + revisions collection):**
+
+```javascript
+// currentPolicies collection — current state only (fast reads)
+{
+  _id: "POL-001",
+  holder: "Jane Smith",
+  premium: 450,
+  coverage: "comprehensive",
+  v: 3,
+  updatedAt: ISODate("2024-06-01")
+}
+
+// policyRevisions collection — full history snapshots
+{
+  policyId: "POL-001",
+  v: 2,
+  snapshot: {
+    holder: "Jane Smith",
+    premium: 425,
+    coverage: "basic",
+    v: 2
+  },
+  changedAt: ISODate("2024-03-15")
+}
+```
+
+**Implementation:**
+
+```javascript
+async function updatePolicy(policyId, newData, session) {
+  const current = await db.currentPolicies.findOne({ _id: policyId }, { session })
+
+  await db.policyRevisions.insertOne({
+    policyId: current._id,
+    v: current.v,
+    snapshot: { ...current },
+    changedAt: new Date()
+  }, { session })
+
+  await db.currentPolicies.updateOne(
+    { _id: policyId },
+    { $set: { ...newData, v: current.v + 1, updatedAt: new Date() } },
+    { session }
+  )
+}
+
+async function getPolicyAtVersion(policyId, version) {
+  if (version === 'current') {
+    return db.currentPolicies.findOne({ _id: policyId })
+  }
+  const rev = await db.policyRevisions.findOne({ policyId, v: version })
+  return rev?.snapshot
+}
+```
+
+**Using Transactions for Atomicity:**
+
+The `updatePolicy` function writes to two collections (inserting a revision **and** updating the current document). It may or may not be prudent to wrap the call in a [multi-document transaction](https://mongodb.com/docs/manual/core/transactions/) to guarantee both writes succeed or fail together, depending on the use case:
+
+```javascript
+const session = client.startSession()
+try {
+  await session.withTransaction(async () => {
+    await updatePolicy("POL-001", { premium: 475, coverage: "premium" }, session)
+  })
+} finally {
+  await session.endSession()
+}
+```
+
+**Indexes:**
+
+```javascript
+db.policyRevisions.createIndex({ policyId: 1, v: -1 })
+// Optional TTL for retention (e.g., 7 years)
+db.policyRevisions.createIndex({ changedAt: 1 }, { expireAfterSeconds: 220752000 })
+```
+
+**Difference from Schema Versioning:**
+
+| Pattern | Purpose | Stores |
+|---------|---------|--------|
+| Schema Versioning | Handle field structure migration | `schemaVersion` field on each doc |
+| Document Versioning | Reproduce complete historical state | Full snapshots in revisions collection |
+
+**When NOT to use this pattern:**
+
+- **High-frequency updates**: If documents change many times per second, use event sourcing instead.
+- **Approximate history is sufficient**: If you only need to know "what changed" but not reproduce exact state.
+- **Unbounded revision growth without retention**: Ensure you have a TTL or archival policy for the revisions collection.
+
+## Verify with
+
+```javascript
+// Check revision collection growth
+db.policyRevisions.aggregate([
+  { $group: {
+    _id: "$policyId",
+    revisionCount: { $sum: 1 },
+    oldestRevision: { $min: "$changedAt" },
+    newestRevision: { $max: "$changedAt" }
+  }},
+  { $sort: { revisionCount: -1 } },
+  { $limit: 10 }
+])
+// Monitor for documents with unexpectedly high revision counts
+
+// Verify current docs have version field
+db.currentPolicies.countDocuments({ v: { $exists: false } })
+// Should be 0 — all documents need version tracking
+
+// Check that revisions are consistent with current version
+db.currentPolicies.aggregate([
+  { $lookup: {
+    from: "policyRevisions",
+    localField: "_id",
+    foreignField: "policyId",
+    as: "revisions"
+  }},
+  { $project: {
+    currentVersion: "$v",
+    revisionCount: { $size: "$revisions" },
+    maxRevisionVersion: { $max: "$revisions.v" }
+  }},
+  { $match: {
+    $expr: { $ne: [{ $subtract: ["$currentVersion", 1] }, "$maxRevisionVersion"] }
+  }}
+])
+// Finds documents where revision history has gaps
+```
+
+Reference: [Keep a History of Document Versions](https://mongodb.com/docs/manual/data-modeling/design-patterns/data-versioning/document-versioning/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-extended-reference.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-extended-reference.md
@@ -1,0 +1,72 @@
+---
+title: Use Extended Reference Pattern
+impact: MEDIUM
+impactDescription: "Reduces repeated `$lookup` on hot paths by caching selected referenced fields"
+tags: schema, patterns, extended-reference, denormalization, caching
+---
+
+## Use Extended Reference Pattern
+
+**Copy frequently-accessed fields from referenced documents into the parent.** If you always display author name with articles, embed it. This eliminates $lookup for common queries while keeping the full data normalized—best of both worlds.
+
+**Incorrect (always $lookup for display data):**
+
+```javascript
+// Order references customer by ID only
+{
+  _id: "order123",
+  customerId: "cust456",  // Customer reference by ID only
+  items: [...],
+  total: 299.99
+}
+
+// Every order list/display requires $lookup
+db.orders.aggregate([
+  { $match: { status: "pending" } },
+  { $lookup: {
+    from: "customers",
+    localField: "customerId",
+    foreignField: "_id",
+    as: "customer"
+  }},
+  { $unwind: "$customer" }
+])
+// Repeated joins add avoidable work for a common list view
+```
+
+**Correct (extended reference):**
+
+Embed frequently-needed customer fields directly in the order document: include a `customer` subdocument with `_id` (kept as a reference for full lookups), `name`, and `email`. The order list query returns customer display data without `$lookup`. Full customer data is still available via a targeted read to the `customers` collection when needed.
+
+**Keeping cached data in sync:**
+
+When the source field changes (e.g. customer name), update the source collection first, then update cached copies in the orders collection using `updateMany` on the embedded reference `_id`. This can be done synchronously or asynchronously via Change Streams / background jobs. For data that changes more often, add a `cachedAt` timestamp to the embedded subdocument so the application can refresh on read when the cache exceeds a staleness threshold.
+
+**What to cache (extend):**
+
+| Cache | Don't Cache |
+|-------|-------------|
+| Display name, avatar | Full bio, description |
+| Status, type | Sensitive PII |
+| Slowly-changing data | Real-time values (balance, inventory) |
+| Fields used in sorting/filtering | Large binary data |
+
+**Alternative: Hybrid pattern with cache expiry:**
+
+Keep both a bare reference (`customerId`) and an optional cache subdocument (`customerCache`) with `name`, `email`, and `cachedAt`. On read, if the cache is missing or older than a threshold (e.g. one day), refresh it from the `customers` collection and write the updated cache back to the order.
+
+**When NOT to use this pattern:**
+
+- **Frequently-changing data**: If customer name changes daily, update overhead exceeds $lookup cost.
+- **Large cached payloads**: Don't embed 50KB of author bio in every article.
+- **Sensitive data segregation**: Don't copy PII into collections with different access controls.
+- **Writes >> Reads**: If writes greatly outnumber reads, caching adds overhead.
+
+## Verify with
+
+Find lookup-heavy aggregations. See how often lookups hit the same collection. High count = candidate for extended reference
+
+For Atlas M10+ use $queryStats. See [Query Stats](references/source-query-stats.md) and [Slow query logs](references/source-slow-query-logs.md)
+Use codebase if available, ask the user.
+
+Reference: [Reduce $lookup Operations](https://mongodb.com/docs/manual/data-modeling/design-antipatterns/reduce-lookup-operations/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-outlier.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-outlier.md
@@ -1,0 +1,159 @@
+---
+title: Use Outlier Pattern for Exceptional Documents
+impact: MEDIUM
+impactDescription: "Isolates unusually large documents so hot-path queries stay optimized for typical cases"
+tags: schema, patterns, outlier, arrays, performance, edge-cases
+---
+
+## Use Outlier Pattern for Exceptional Documents
+
+**Isolate atypical documents with large arrays to prevent them from degrading performance for typical queries.** When a small subset of documents is much larger than the rest, those outliers can dominate memory, index, and query costs. Split overflow data into a separate collection and flag the document.
+
+**Problem scenario:**
+
+A typical book might have 50 customers in an embedded array, while a bestseller like Harry Potter accumulates 50,000 (~2.5MB). Queries return the full document, so the outlier dominates memory and network cost. A multikey index on that array produces 50,000 entries for a single document.
+
+**Correct (outlier pattern):**
+
+Typical documents keep their full embedded array and set `hasExtras: false`. Outlier documents cap the embedded array at a threshold (e.g. 50), set `hasExtras: true`, store a denormalized `customerCount`, and overflow remaining items into a separate collection in batched documents (e.g. `{ bookId, customers: [...], batch: 1, count: 950 }`). Application code checks the `hasExtras` flag to decide whether to load overflow batches.
+
+**Implementation with threshold (example; tune per workload):**
+
+```javascript
+const CUSTOMER_THRESHOLD = 50
+
+async function addCustomer(bookId, customerId) {
+  // Try the normal case first: atomically add to the embedded array only if
+  // the current customerCount is below the threshold (treat missing/null as 0).
+  const result = await db.books.updateOne(
+    {
+      _id: bookId,
+      $or: [
+        { customerCount: { $lt: CUSTOMER_THRESHOLD } },
+        { customerCount: { $exists: false } },
+        { customerCount: null }
+      ]
+    },
+    {
+      $push: { customers: customerId },
+      $inc: { customerCount: 1 }
+    }
+  )
+
+  if (result.matchedCount > 0) {
+    // Normal case succeeded - customer added to embedded array
+    return
+  }
+
+  // Outlier case - add to overflow collection
+  const lastBatchDoc = await db.book_customers_extra
+    .find({ bookId: bookId })
+    .sort({ batch: -1 })
+    .limit(1)
+    .next()
+
+  const nextBatch = lastBatchDoc ? lastBatchDoc.batch + 1 : 1
+  const targetBatch =
+    lastBatchDoc && lastBatchDoc.count < 1000
+      ? lastBatchDoc.batch
+      : nextBatch
+
+  // First, try to append to the intended batch, enforcing the 1000-item cap under concurrency.
+  const overflowFilter = { bookId: bookId, batch: targetBatch }
+  if (targetBatch !== nextBatch) {
+    // Only enforce the count cap when targeting an existing batch.
+    overflowFilter.count = { $lt: 1000 }
+  }
+
+  const overflowResult = await db.book_customers_extra.updateOne(
+    overflowFilter, // Write to the intended batch, respecting the count cap when reusing a batch
+    {
+      $push: { customers: customerId },
+      $inc: { count: 1 },
+      $setOnInsert: { bookId: bookId, batch: targetBatch }
+    },
+    { upsert: targetBatch === nextBatch }
+  )
+
+  // If we failed to match when trying to reuse the previous batch (it filled concurrently),
+  // fall back to writing into the next batch.
+  if (overflowResult.matchedCount === 0 && targetBatch !== nextBatch) {
+    await db.book_customers_extra.updateOne(
+      { bookId: bookId, batch: nextBatch },
+      {
+        $push: { customers: customerId },
+        $inc: { count: 1 },
+        $setOnInsert: { bookId: bookId, batch: nextBatch }
+      },
+      { upsert: true }
+    )
+  }
+
+  await db.books.updateOne(
+    { _id: bookId },
+    {
+      $set: { hasExtras: true },
+      $inc: { customerCount: 1 }
+    }
+  )
+}
+```
+
+**Index strategy:**
+
+```javascript
+// Index on main collection - only 50 entries per outlier doc
+db.books.createIndex({ "customers": 1 })
+
+// Index on overflow collection
+db.book_customers_extra.createIndex({ bookId: 1 })
+db.book_customers_extra.createIndex({ customers: 1 })
+```
+
+**When to use outlier pattern:**
+
+| Scenario | What to measure | Example |
+|----------|-----------------|---------|
+| Book customers | Array-size distribution and long tail | Bestsellers vs. typical books |
+| Social followers | Growth rate and read-path impact | Celebrities vs. regular users |
+| Product reviews | Index fan-out and read locality | Viral products vs. typical |
+| Event attendees | Outlier frequency vs. implementation complexity | Major events vs. small meetups |
+
+**When NOT to use this pattern:**
+
+- **Uniform distribution**: If all documents have similar array sizes, no outliers to isolate.
+- **Always need full data**: If you always display all 50,000 customers, pattern doesn't help.
+- **Write-heavy outliers**: Complex update logic may not be worth the read optimization.
+- **Small outliers**: If outliers are 200 vs typical 50, just use larger threshold.
+
+## Verify with
+
+```javascript
+// Find outlier documents
+db.books.aggregate([
+  { $project: {
+    title: 1,
+    customerCount: { $size: { $ifNull: ["$customers", []] } }
+  }},
+  { $sort: { customerCount: -1 } },
+  { $limit: 20 }
+])
+
+// Calculate distribution
+db.books.aggregate([
+  { $project: { count: { $size: { $ifNull: ["$customers", []] } } } },
+  { $bucket: {
+    groupBy: "$count",
+    boundaries: [0, 50, 100, 500, 1000, 10000, 100000],
+    default: "100000+",
+    output: { count: { $sum: 1 } }
+  }}
+])
+// Look for a long-tail distribution where a small subset is far above median/p95
+
+// Check index sizes
+db.books.stats().indexSizes
+// Large multikey index suggests outliers are bloating it
+```
+
+Reference: [Outlier Pattern](https://mongodb.com/docs/manual/data-modeling/design-patterns/group-data/outlier-pattern/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-polymorphic.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-polymorphic.md
@@ -1,0 +1,167 @@
+---
+title: Use Polymorphic Pattern for Heterogeneous Documents
+impact: MEDIUM
+impactDescription: "Keeps related entities in one collection while preserving type-specific fields"
+tags: schema, patterns, polymorphic, discriminator, flexible-schema, indexing, single-collection
+---
+
+## Use Polymorphic Pattern for Heterogeneous Documents
+
+**Store related but different document shapes in one collection with a type discriminator.** This keeps shared queries and indexes simple while allowing type-specific fields. Common use cases: product catalogs with different product types, content management systems, event stores, and any domain with inheritance.
+
+**Incorrect (separate collections per subtype):**
+
+Using a separate collection per product type (e.g. `products_books`, `products_electronics`, `products_clothing`) means querying across all products requires multiple calls or `$unionWith`, shared indexes must be duplicated, adding new types requires new collections, and application code must branch on collection names.
+
+**Correct (single collection using optional fields):**
+
+Store all product types in one `products` collection. All documents share common fields (`name`, `price`, `inStock`); each type adds its own specific fields (books: `author`, `isbn`, `pages`; electronics: `brand`, `wattage`, `batteryHours`, `warranty`; clothing: `size`, `color`, `material`). If the categories are always fully disjoint, use a `type` discriminator field (e.g. `"book"`, `"electronics"`, `"clothing"`). Cross-type queries use shared fields; type-specific queries filter by `type` plus type-specific fields. If there is potential overlap (e.g. between different categories of users), you can omit this field and rely entirely on optional fields.
+
+**Index strategies for polymorphic collections:**
+
+```javascript
+// Strategy 1: Compound index with type first
+// Best for: Queries that always filter by type
+db.products.createIndex({ type: 1, price: 1 })
+db.products.createIndex({ type: 1, name: 1 })
+
+// Query uses index efficiently:
+db.products.find({ type: "book", price: { $lt: 50 } })
+
+// Strategy 2: Compound index with type second
+// Best for: Queries that rarely filter by type
+db.products.createIndex({ price: 1, type: 1 })
+
+// Query across all types uses index:
+db.products.find({ price: { $lt: 50 } })
+
+// Strategy 3: Partial indexes for type-specific fields
+// Best for: Fields that only exist on some types
+db.products.createIndex(
+  { author: 1 },
+  { partialFilterExpression: { type: "book" } }
+)
+
+db.products.createIndex(
+  { brand: 1, wattage: 1 },
+  { partialFilterExpression: { type: "electronics" } }
+)
+
+// Strategy 4: Wildcard index for varying fields
+// Best for: Many type-specific fields, ad-hoc queries
+db.products.createIndex({ "specs.$**": 1 })
+
+// Documents store type-specific data in specs:
+{ type: "book", specs: { author: "...", isbn: "..." } }
+{ type: "electronics", specs: { brand: "...", wattage: 20 } }
+```
+
+**Query patterns across types:**
+
+```javascript
+// Pattern 1: Query all types with shared fields
+db.products.find({ price: { $lt: 100 }, inStock: true })
+  .sort({ price: 1 })
+
+// Pattern 2: Query specific type with type-specific fields
+db.products.find({
+  type: "book",
+  pages: { $gt: 300 },
+  author: /bradshaw/i
+})
+
+// Pattern 3: Aggregation across types with type-specific handling
+db.products.aggregate([
+  { $match: { inStock: true } },
+  { $group: {
+      _id: "$type",
+      count: { $sum: 1 },
+      avgPrice: { $avg: "$price" }
+    }
+  }
+])
+
+// Pattern 4: Faceted search with type breakdown
+db.products.aggregate([
+  { $match: { price: { $lt: 100 } } },
+  { $facet: {
+      byType: [{ $group: { _id: "$type", count: { $sum: 1 } } }],
+      priceRanges: [
+        { $bucket: {
+            groupBy: "$price",
+            boundaries: [0, 25, 50, 100],
+            default: "100+"
+          }
+        }
+      ]
+    }
+  }
+])
+```
+
+**Validation per type:**
+
+```javascript
+// Use JSON Schema with discriminator-based validation
+db.runCommand({
+  collMod: "products",
+  validator: {
+    $jsonSchema: {
+      bsonType: "object",
+      required: ["type", "name", "price"],
+      properties: {
+        type: { enum: ["book", "electronics", "clothing"] },
+        name: { bsonType: "string" },
+        price: { bsonType: "number", minimum: 0 }
+      },
+      oneOf: [
+        {
+          properties: { type: { enum: ["book"] } },
+          required: ["author", "isbn"]
+        },
+        {
+          properties: { type: { enum: ["electronics"] } },
+          required: ["brand"]
+        },
+        {
+          properties: { type: { enum: ["clothing"] } },
+          required: ["size", "color"]
+        }
+      ]
+    }
+  },
+  validationLevel: "moderate"
+})
+```
+
+**Adding new types:**
+
+The polymorphic pattern makes adding types straightforward — no schema migration needed. Insert documents with the new `type` value and any type-specific fields. Add partial indexes for type-specific queries as needed, and update schema validation to include the new type if using strict validation.
+
+**When NOT to use polymorphic pattern:**
+
+- **Completely different access patterns**: If each type is queried independently with no cross-type queries, separate collections may be cleaner.
+- **Conflicting index requirements**: If types need many different indexes, the index overhead may outweigh benefits.
+- **Strict type separation required**: Regulatory or security requirements may mandate separate collections.
+- **Vastly different document sizes**: If one type has 100-byte docs and another has 100KB docs, working set suffers.
+- **Type-specific sharding needs**: Different types may need different shard keys.
+
+## Verify with
+
+```javascript
+// Get type distribution
+db.products.aggregate([
+  { $group: {
+      _id: "$type",
+      count: { $sum: 1 },
+      avgSize: { $avg: { $bsonSize: "$$ROOT" } }
+    }
+  },
+  { $sort: { count: -1 } }
+])
+
+// Check for missing type field
+db.products.countDocuments({ type: { $exists: false } })
+```
+
+Reference: [Polymorphic Schema Pattern](https://mongodb.com/docs/manual/data-modeling/design-patterns/polymorphic-data/polymorphic-schema-pattern/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-schema-versioning.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-schema-versioning.md
@@ -1,0 +1,273 @@
+---
+title: Schema Evolution and Preventing Drift
+impact: CRITICAL
+impactDescription: "Prevents application errors from inconsistent schemas and enables safe online migrations"
+tags: schema, patterns, versioning, migration, evolution, backward-compatibility, backfill, anti-pattern, validation, consistency, data-quality, atlas-suggestion
+---
+
+## Schema Evolution and Preventing Drift
+
+**Schema changes are inevitable, but uncontrolled changes cause schema drift** — documents in the same collection with inconsistent structures, leading to application errors and query failures. Use `schemaVersion` fields for safe migration and schema validation to prevent unexpected drift.
+
+### The problem: schema drift
+
+MongoDB's flexibility is a feature, but undisciplined field additions lead to code that must handle many document shapes.
+
+**Incorrect (uncontrolled drift over time):**
+
+```javascript
+// Over time, different versions of "user" documents accumulate
+{ _id: 1, name: "Alice", email: "alice@ex.com" }                  // 2021
+{ _id: 3, firstName: "Carol", lastName: "Smith", email: "carol@ex.com" }  // 2022 - restructured name
+{ _id: 4, firstName: "Dave", lastName: "Jones", emails: ["dave@ex.com"] } // 2023 - email → emails
+
+// Application code becomes defensive nightmare
+function getUserEmail(user) {
+  if (user.email) return user.email
+  if (user.emails) return user.emails[0]
+  throw new Error("No email found")
+}
+
+// Queries fail silently
+db.users.find({ email: "test@ex.com" })  // Misses users with emails[] array
+```
+
+### Solution: versioned documents with migration path
+
+Add a `schemaVersion` field to every document. Application code checks version and handles both formats. This allows old and new documents to coexist, new code to deploy before data migration, gradual migration during low-traffic periods, and easy rollback.
+
+**Correct (versioned with validation):**
+
+```javascript
+// Define and enforce consistent schema
+db.createCollection("users", {
+  validator: {
+    $jsonSchema: {
+      bsonType: "object",
+      required: ["emails", "profile", "schemaVersion"],
+      properties: {
+        emails: {
+          bsonType: "array",
+          items: {
+            bsonType: "string",
+            pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+          }
+        },
+        profile: {
+          bsonType: "object",
+          required: ["firstName", "lastName"],
+          properties: {
+            firstName: { bsonType: "string", minLength: 1 },
+            lastName: { bsonType: "string", minLength: 1 }
+          }
+        },
+        schemaVersion: {
+          bsonType: "int",
+          enum: [1, 2]  // Accept both during migration
+        }
+      }
+    }
+  },
+  validationLevel: "strict",
+  validationAction: "error"
+})
+```
+
+### Online migration strategies
+
+```javascript
+// Strategy 1: Background batch migration
+// Best for: Large collections, can tolerate mixed versions temporarily
+
+function migrateToV2(batchSize = 1000) {
+  let migrated = 0
+  let cursor = db.users.find({ schemaVersion: { $lt: 2 } }).limit(batchSize)
+
+  for (const doc of cursor) {
+    const [firstName, ...rest] = (doc.name || "").split(" ")
+    const lastName = rest.join(" ") || "Unknown"
+
+    db.users.updateOne(
+      { _id: doc._id, schemaVersion: { $lt: 2 } },  // Prevent double-migration
+      {
+        $set: {
+          schemaVersion: 2,
+          profile: { firstName, lastName },
+          emails: doc.emails || (doc.email ? [doc.email] : []),
+        },
+        $unset: { name: "", email: "" }
+      }
+    )
+    migrated++
+  }
+  return migrated
+}
+
+// Run in batches during off-peak hours
+while (migrateToV2(1000) > 0) {
+  sleep(100)  // Throttle to reduce load
+}
+
+
+// Strategy 2: Aggregation pipeline update (MongoDB 4.2+)
+// Best for: Simple transformations, moderate collection sizes
+
+db.users.updateMany(
+  { schemaVersion: { $lt: 2 } },
+  [
+    {
+      $set: {
+        schemaVersion: 2,
+        profile: {
+          $cond: {
+            if: { $eq: [{ $type: "$name" }, "string"] },
+            then: {
+              firstName: { $arrayElemAt: [{ $split: ["$name", " "] }, 0] },
+              lastName: { $ifNull: [
+                { $arrayElemAt: [{ $split: ["$name", " "] }, 1] },
+                "Unknown"
+              ]}
+            },
+            else: "$profile"
+          }
+        },
+        emails: {
+          $cond: {
+            if: { $eq: [{ $type: "$email" }, "string"] },
+            then: ["$email"],
+            else: { $ifNull: ["$emails", []] }
+          }
+        },
+      }
+    },
+    { $unset: ["name", "email"] }
+  ]
+)
+
+
+// Strategy 3: Read-time migration (lazy migration)
+// Best for: Low-traffic documents, immediate consistency needed
+
+function getUser(userId) {
+  const user = db.users.findOne({ _id: userId })
+
+  if (user && user.schemaVersion < 2) {
+    const migrated = migrateUserToV2(user)
+    db.users.replaceOne({ _id: userId }, migrated)
+    return migrated
+  }
+
+  return user
+}
+```
+
+### Handling multiple version jumps
+
+```javascript
+// v1 → v2 → v3: define transformation functions for each step
+const migrations = {
+  1: (doc) => ({
+    ...doc,
+    schemaVersion: 2,
+    profile: {
+      firstName: doc.name.split(" ")[0],
+      lastName: doc.name.split(" ").slice(1).join(" ") || "Unknown"
+    },
+    emails: doc.email ? [doc.email] : []
+  }),
+  2: (doc) => ({
+    ...doc,
+    schemaVersion: 3,
+    profile: {
+      ...doc.profile,
+      displayName: `${doc.profile.firstName} ${doc.profile.lastName}`
+    }
+  })
+}
+
+function migrateToLatest(doc, targetVersion = 3) {
+  let current = doc
+  while (current.schemaVersion < targetVersion) {
+    const migrator = migrations[current.schemaVersion]
+    if (!migrator) throw new Error(`No migration from v${current.schemaVersion}`)
+    current = migrator(current)
+  }
+  return current
+}
+```
+
+### When a version bump is (and isn't) needed
+
+**No version bump needed (backward-compatible):**
+- Adding new optional fields (old code ignores them)
+- Adding new indexes (transparent to application)
+- Relaxing validation (making a required field optional)
+
+**Version bump required (breaking):**
+- Renaming fields (`address` → `shippingAddress`)
+- Changing field types (`price: "19.99"` → `price: 19.99`)
+- Restructuring (flat `firstName`/`lastName` → nested `name: { first, last }`)
+- Removing fields that old code reads
+
+### Detecting existing schema drift
+
+```javascript
+// Find all unique field combinations
+db.users.aggregate([
+  { $project: { fields: { $objectToArray: "$$ROOT" } } },
+  { $project: { keys: "$fields.k" } },
+  { $group: { _id: "$keys", count: { $sum: 1 } } },
+  { $sort: { count: -1 } }
+])
+// Multiple distinct key-sets = schema drift exists
+
+// Find documents missing required fields
+db.users.find({
+  $or: [
+    { emails: { $exists: false } },
+    { profile: { $exists: false } },
+    { "profile.firstName": { $exists: false } }
+  ]
+})
+
+// Find documents with wrong field types
+db.users.find({
+  emails: { $not: { $type: "array" } }
+})
+```
+
+### When NOT to strictly enforce schema or use versioning
+
+- **Truly polymorphic data**: Event logs with different event types may need flexible schemas — use `pattern-polymorphic` instead.
+- **Early prototyping**: Skip validation during exploration, add before production.
+- **User-defined fields**: Some applications allow custom metadata fields.
+- **Small datasets with downtime window**: If you can migrate all data in minutes during maintenance.
+- **Additive-only changes**: If you only add optional fields, versioning is overkill.
+
+## Verify with
+
+```javascript
+// Track version distribution
+db.users.aggregate([
+  { $group: { _id: "$schemaVersion", count: { $sum: 1 } } },
+  { $sort: { _id: 1 } }
+])
+
+// Check for missing version field (implicit v1 documents)
+db.users.countDocuments({ schemaVersion: { $exists: false } })
+
+// Check if validation exists on the collection
+const collInfo = db.getCollectionInfos({ name: "users" })[0]
+const validator = collInfo?.options?.validator
+// Missing validator = higher schema drift risk
+
+// Find documents that don't match current validator
+if (validator) {
+  db.users.find({ $nor: [validator] }).limit(20)
+  db.users.countDocuments({ $nor: [validator] })
+}
+```
+
+References:
+- [Schema Versioning Pattern](https://mongodb.com/docs/manual/data-modeling/design-patterns/data-versioning/schema-versioning/)
+- [Schema Validation](https://mongodb.com/docs/manual/core/schema-validation/)

--- a/.agents/skills/mongodb-schema-design/references/pattern-time-series-collections.md
+++ b/.agents/skills/mongodb-schema-design/references/pattern-time-series-collections.md
@@ -1,0 +1,190 @@
+---
+title: Use Time Series Collections for Time Series Data
+impact: MEDIUM
+impactDescription: "10-100× lower storage and index overhead with automatic bucketing and compression"
+tags: schema, patterns, time-series, collections, bucketing, ttl, granularity, compression
+---
+
+## Use Time Series Collections for Time Series Data
+
+**Time series collections are purpose-built for append-only measurements.** MongoDB automatically buckets, compresses, and indexes time series data so you get high ingest rates with far less storage and index overhead than a standard collection. Use them for IoT sensor data, application metrics, financial data, and event logs.
+
+**MongoDB 8.0 Performance:** Block processing introduced in MongoDB 8.0 can significantly improve eligible analytical pipelines (for example, `$match` + `$sort` on the time field + `$group`). In some cases, throughput improves by more than 200%. This is automatic for eligible queries.
+
+**Incorrect (regular collection for measurements):**
+
+```javascript
+// Regular collection: one document per reading
+// Creates huge collections and indexes at scale
+{
+  sensorId: "temp-01",
+  ts: ISODate("2025-01-15T10:00:00Z"),
+  value: 22.5
+}
+
+// Problems:
+// 1. Each measurement is a separate document
+// 2. Index overhead per document
+// 3. No automatic compression
+// 4. Working set grows linearly
+
+// Standard index (large and grows fast)
+db.sensor_data.createIndex({ sensorId: 1, ts: 1 })
+```
+
+**Correct (time series collection with optimized settings):**
+
+```javascript
+// Create time series collection with careful configuration
+db.createCollection("sensor_data", {
+  timeseries: {
+    timeField: "ts",           // Required: timestamp field
+    metaField: "metadata",     // Recommended: grouping field
+    granularity: "minutes"     // Match your data rate
+  },
+  expireAfterSeconds: 60 * 60 * 24 * 90  // 90-day retention
+})
+
+// Insert documents - MongoDB buckets automatically
+db.sensor_data.insertOne({
+  metadata: { sensorId: "temp-01", location: "building-A" },
+  ts: new Date(),
+  value: 22.5,
+  unit: "celsius"
+})
+
+// Benefits:
+// - Automatic bucketing (many measurements per internal doc)
+// - Column compression (40-60% disk reduction)
+// - MongoDB 6.3+: auto-created compound index on metaField + timeField for new collections
+// - Optimized for time-range queries
+```
+
+**Choose the right metaField:**
+
+```javascript
+// metaField groups measurements into buckets
+// Choose fields that:
+// 1. Are queried together with time ranges
+// 2. Have moderate cardinality (not too unique, not too few)
+// 3. Don't change for a given time series
+
+// GOOD: Sensor/device identifier as metaField
+{
+  metadata: { sensorId: "temp-01", region: "us-east" },
+  ts: new Date(),
+  value: 22.5
+}
+// Queries like: "All readings from temp-01 in last hour"
+
+// BAD: High-cardinality field as metaField
+{
+  metadata: { requestId: "uuid-123..." },  // Unique per doc!
+  ts: new Date()
+}
+// Creates one bucket per requestId - no compression benefit
+
+// BAD: Frequently changing field in metaField
+{
+  metadata: { sensorId: "temp-01", currentValue: 22.5 },  // Changes!
+  ts: new Date()
+}
+// metaField should be static for the time series
+```
+
+**Select appropriate granularity:**
+
+```javascript
+// Granularity determines bucket time span
+// Match it to your data ingestion rate
+
+// "seconds" - DEFAULT. High-frequency ingestion. Bucket spans ~1 hour.
+db.createCollection("high_freq_metrics", {
+  timeseries: { timeField: "ts", metaField: "host", granularity: "seconds" }
+})
+
+// "minutes" - Data every few seconds to minutes. Bucket spans ~24 hours.
+db.createCollection("app_metrics", {
+  timeseries: { timeField: "ts", metaField: "service", granularity: "minutes" }
+})
+
+// "hours"   - Data every few hours. Bucket spans ~30 days.
+db.createCollection("daily_reports", {
+  timeseries: { timeField: "ts", metaField: "reportType", granularity: "hours" }
+})
+
+// Custom bucketing (MongoDB 6.3+) for precise control
+db.createCollection("custom_metrics", {
+  timeseries: {
+    timeField: "ts",
+    metaField: "device",
+    bucketMaxSpanSeconds: 3600,      // Max 1 hour per bucket
+    bucketRoundingSeconds: 3600      // Align to hour boundaries
+  }
+})
+```
+
+**Optimize insert performance:**
+
+```javascript
+// Batch inserts with insertMany
+// Group documents with same metaField value together
+const batch = [
+  { metadata: { sensorId: "temp-01" }, ts: new Date(), value: 22.5 },
+  { metadata: { sensorId: "temp-01" }, ts: new Date(), value: 22.6 },
+  { metadata: { sensorId: "temp-02" }, ts: new Date(), value: 19.2 },
+]
+
+db.sensor_data.insertMany(batch, { ordered: false })
+// ordered: false allows parallel processing
+// Use consistent field order and omit empty values for better compression
+```
+
+**Secondary indexes on time series:**
+
+```javascript
+// MongoDB 6.3+: time series auto-creates index on { metaField, timeField } for new collections
+// Add secondary indexes for other query patterns
+
+// Index on measurement values for threshold queries
+db.sensor_data.createIndex({ "value": 1 })
+// Query: "All readings where value > 100"
+
+// Compound index for filtered time queries
+db.sensor_data.createIndex({ "metadata.location": 1, "ts": 1 })
+// Query: "Readings from building-A in last hour"
+
+// Partial index for specific conditions
+db.sensor_data.createIndex(
+  { "metadata.alertLevel": 1 },
+  { partialFilterExpression: { "metadata.alertLevel": { $exists: true } } }
+)
+```
+
+**When NOT to use time series collections:**
+
+- **Not time-based data**: Primary access isn't time range queries.
+- **Frequent updates/deletes**: Time series optimized for append-only; updates to old data are slow.
+- **Very low volume**: A few hundred events don't benefit from bucketing.
+- **Need transactional writes**: Time series collections don't support writes in transactions (reads are supported).
+- **Complex queries on measurements**: If you mostly query by non-time fields, regular collections may be better.
+
+## Verify with
+
+```javascript
+// Get collection info
+const info = db.getCollectionInfos({ name: "sensor_data" })[0]
+const ts = info?.options?.timeseries
+// Check timeField, metaField, granularity, expireAfterSeconds
+
+// Check bucket efficiency (via system.buckets)
+const bucketColl = `system.buckets.sensor_data`
+const bucketCount = db.getCollection(bucketColl).countDocuments({})
+const stats = db.sensor_data.stats()
+if (bucketCount > 0 && stats.count) {
+  const docsPerBucket = stats.count / bucketCount
+  // Low docs/bucket suggests adjusting granularity or metaField
+}
+```
+
+Reference: [Time Series Collections](https://mongodb.com/docs/manual/core/timeseries-collections/)

--- a/.agents/skills/mongodb-schema-design/references/source-query-stats.md
+++ b/.agents/skills/mongodb-schema-design/references/source-query-stats.md
@@ -1,0 +1,123 @@
+# Query Stats
+
+## When to use
+
+Analyzes query access patterns with minimal performance overhead. Use for identifying co-accessed fields, collection relationships, and query frequencies. Only supports `find`, `aggregate`, and `distinct` operations.
+
+## Requirements
+
+Atlas M10+ tier.
+
+## How to use
+
+Aggregate on the admin database.
+
+With mcp-server, use the `mcp__mongodb__aggregateDB` tool with database set to `admin`.
+
+```javascript
+db.getSiblingDB("admin").aggregate([{ $queryStats: {} }])
+```
+
+**Example 1: Find collections frequently queried together with others (embedding candidates)**
+```javascript
+db.aggregate([
+  { $queryStats: {} },
+  {
+    $match: {
+      "key.queryShape.cmdNs.db": "databaseName",
+      "key.queryShape.command": "aggregate",
+      "key.queryShape.pipeline.$lookup": { $exists: true }
+    }
+  },
+  { $unwind: "$key.queryShape.pipeline" },
+  { 
+    $match: { "key.queryShape.pipeline.$lookup": { $exists: true } } 
+  },
+  { 
+    $set: { 
+      stageKeyValue: { 
+        $first: { $objectToArray: "$key.queryShape.pipeline" } 
+      } 
+    }
+  },
+  { 
+    $group: {
+      _id: { 
+        source: "$key.queryShape.cmdNs.coll",
+        target: "$stageKeyValue.v.from"
+      },
+      totalLookupHits: { $sum: "$metrics.execCount" },
+      avgPipelineMs: {
+        $avg: { $divide: [
+          { $divide: ["$metrics.totalExecMicros.sum", 1000] },
+          "$metrics.execCount"
+        ]}
+      }
+    }
+  },
+  { $sort: { totalLookupHits: -1 } }
+])
+
+// High totalLookupHits = frequently joined 
+// High avgPipelineMS = lookup is part of slow queries (does not automatically mean that the $lookup is slow, could be the whole pipeline - see the full query shapes)
+// High scores on both - consider embedding to avoid $lookup 
+```
+
+**Example 1.1: Find query shapes that use $lookup on specific collections**
+```javascript
+db.aggregate([
+  { $queryStats: {} },
+  {
+    $match: {
+      "key.queryShape.cmdNs.db": "databaseName",
+      "key.queryShape.command": "aggregate",
+      "key.queryShape.cmdNs.coll": "sourceCollectionName",
+      "key.queryShape.pipeline.$lookup.from": "targetCollectionName"
+    }
+  },
+  {
+    $project: {
+      database: "$key.queryShape.cmdNs.db",
+      collection: "$key.queryShape.cmdNs.coll",
+      pipeline: "$key.queryShape.pipeline",
+      execCount: "$metrics.execCount",
+      avgMs: {
+          $divide: [
+            { $divide: ["$metrics.totalExecMicros.sum", 1000] },
+            "$metrics.execCount"
+          ]
+      }
+    },
+  },
+  { $sort: { execCount: -1 } },
+  { $limit: 10 }
+])
+```
+
+**Example 2: Find top most frequent query shapes (optimize hot paths)**
+```javascript
+db.getSiblingDB("admin").aggregate([
+  { $queryStats: {} },
+  { $sort: { "metrics.execCount": -1 } },
+  { $limit: 10 },
+  {
+    $project: {
+      command: "$key.queryShape.command",
+      database: "$key.queryShape.cmdNs.db",
+      collection: "$key.queryShape.cmdNs.coll",
+      queryShape: "$key.queryShape",
+      execCount: "$metrics.execCount",
+      avgMs: {
+        $divide: [
+          { $divide: ["$metrics.totalExecMicros.sum", 1000] },
+          "$metrics.execCount"
+        ]
+      }
+    }
+  }
+])
+
+// High execCount = hot path → design your schema for these queries first
+// Cross reference with avgMS or [slow query logs](references/source-slow-query-logs.md) to find queries that are both frequent and slow
+// Note: Query stats do not include write patterns (update, insert)
+```

--- a/.agents/skills/mongodb-schema-design/references/source-slow-query-logs.md
+++ b/.agents/skills/mongodb-schema-design/references/source-slow-query-logs.md
@@ -1,0 +1,63 @@
+# Atlas Slow Query Logs
+
+## When to use
+
+Retrieves log lines for slow queries as determined by the Performance Advisor. Use to identify slow queries and performance bottlenecks. Provides actual query examples (not shapes) with execution times. Captures all operation types including writes, unlike Query Stats which currently only covers find/aggregate/distinct.
+
+## Requirements
+
+- Atlas M10+ cluster
+- Atlas API credentials configured
+- Performance Advisor enabled (enabled by default on M10+)
+
+If the API call returns auth or access errors, see the [Performance Advisor docs](https://www.mongodb.com/docs/atlas/performance-advisor/).
+
+## How to use
+
+Atlas Admin API endpoint ([query parameters reference](https://www.mongodb.com/docs/ops-manager/current/reference/api/performance-advisor/get-slow-queries/#request-query-parameters)):
+```
+GET /groups/{PROJECT-ID}/hosts/{HOST-ID}/performanceAdvisor/slowQueryLogs
+```
+
+With MongoDB MCP server:
+```javascript
+mcp__plugin_mongodb_mongodb__atlas-get-performance-advisor({
+  projectId: "507f1f77bcf86cd799439011",
+  clusterName: "MyCluster",
+  operations: ["slowQueryLogs"]
+})
+```
+
+Performance Advisor analyzes up to 200,000 of the cluster's most recent log lines.
+
+**Example response structure:**
+```javascript
+{
+  "slowQueries": [
+    {
+      "line": "2026-05-06T10:23:45.447+0000 I COMMAND [conn10614] command mydb.orders appName: \"MongoDB Shell\" command: find { find: \"orders\", filter: { status: \"pending\", customerId: 12345 }, sort: { createdAt: -1 } } planSummary: COLLSCAN keysExamined:0 docsExamined:50000 nreturned:100 executionTimeMillis:1247 ...",
+      "namespace": "mydb.orders"
+    }
+  ]
+}
+```
+
+The response contains raw log lines. Parse the log line to extract:
+- Timestamp (beginning of line)
+- Operation type (command: find, aggregate, update, etc.)
+- Query details (filter, pipeline, etc.)
+- Execution metrics (executionTimeMillis, docsExamined, planSummary, etc.)
+
+## What to Look For
+
+When analyzing slow query logs, focus on:
+
+**Slow $lookup operations:**
+- Look for `$lookup` in the log line
+- Consider embedding to reduce slow $lookup operations
+- Cross-reference with Query Stats to identify frequent lookups
+- High executionTimeMillis + high frequency = urgent schema redesign
+
+**Other slow aggregations:**
+- Consider the Computed Pattern to avoid slow aggregations
+

--- a/.agents/skills/systematic-debugging/CREATION-LOG.md
+++ b/.agents/skills/systematic-debugging/CREATION-LOG.md
@@ -1,0 +1,119 @@
+# Creation Log: Systematic Debugging Skill
+
+Reference example of extracting, structuring, and bulletproofing a critical skill.
+
+## Source Material
+
+Extracted debugging framework from `~/.claude/CLAUDE.md`:
+- 4-phase systematic process (Investigation → Pattern Analysis → Hypothesis → Implementation)
+- Core mandate: ALWAYS find root cause, NEVER fix symptoms
+- Rules designed to resist time pressure and rationalization
+
+## Extraction Decisions
+
+**What to include:**
+- Complete 4-phase framework with all rules
+- Anti-shortcuts ("NEVER fix symptom", "STOP and re-analyze")
+- Pressure-resistant language ("even if faster", "even if I seem in a hurry")
+- Concrete steps for each phase
+
+**What to leave out:**
+- Project-specific context
+- Repetitive variations of same rule
+- Narrative explanations (condensed to principles)
+
+## Structure Following skill-creation/SKILL.md
+
+1. **Rich when_to_use** - Included symptoms and anti-patterns
+2. **Type: technique** - Concrete process with steps
+3. **Keywords** - "root cause", "symptom", "workaround", "debugging", "investigation"
+4. **Flowchart** - Decision point for "fix failed" → re-analyze vs add more fixes
+5. **Phase-by-phase breakdown** - Scannable checklist format
+6. **Anti-patterns section** - What NOT to do (critical for this skill)
+
+## Bulletproofing Elements
+
+Framework designed to resist rationalization under pressure:
+
+### Language Choices
+- "ALWAYS" / "NEVER" (not "should" / "try to")
+- "even if faster" / "even if I seem in a hurry"
+- "STOP and re-analyze" (explicit pause)
+- "Don't skip past" (catches the actual behavior)
+
+### Structural Defenses
+- **Phase 1 required** - Can't skip to implementation
+- **Single hypothesis rule** - Forces thinking, prevents shotgun fixes
+- **Explicit failure mode** - "IF your first fix doesn't work" with mandatory action
+- **Anti-patterns section** - Shows exactly what shortcuts look like
+
+### Redundancy
+- Root cause mandate in overview + when_to_use + Phase 1 + implementation rules
+- "NEVER fix symptom" appears 4 times in different contexts
+- Each phase has explicit "don't skip" guidance
+
+## Testing Approach
+
+Created 4 validation tests following skills/meta/testing-skills-with-subagents:
+
+### Test 1: Academic Context (No Pressure)
+- Simple bug, no time pressure
+- **Result:** Perfect compliance, complete investigation
+
+### Test 2: Time Pressure + Obvious Quick Fix
+- User "in a hurry", symptom fix looks easy
+- **Result:** Resisted shortcut, followed full process, found real root cause
+
+### Test 3: Complex System + Uncertainty
+- Multi-layer failure, unclear if can find root cause
+- **Result:** Systematic investigation, traced through all layers, found source
+
+### Test 4: Failed First Fix
+- Hypothesis doesn't work, temptation to add more fixes
+- **Result:** Stopped, re-analyzed, formed new hypothesis (no shotgun)
+
+**All tests passed.** No rationalizations found.
+
+## Iterations
+
+### Initial Version
+- Complete 4-phase framework
+- Anti-patterns section
+- Flowchart for "fix failed" decision
+
+### Enhancement 1: TDD Reference
+- Added link to skills/testing/test-driven-development
+- Note explaining TDD's "simplest code" ≠ debugging's "root cause"
+- Prevents confusion between methodologies
+
+## Final Outcome
+
+Bulletproof skill that:
+- ✅ Clearly mandates root cause investigation
+- ✅ Resists time pressure rationalization
+- ✅ Provides concrete steps for each phase
+- ✅ Shows anti-patterns explicitly
+- ✅ Tested under multiple pressure scenarios
+- ✅ Clarifies relationship to TDD
+- ✅ Ready for use
+
+## Key Insight
+
+**Most important bulletproofing:** Anti-patterns section showing exact shortcuts that feel justified in the moment. When Claude thinks "I'll just add this one quick fix", seeing that exact pattern listed as wrong creates cognitive friction.
+
+## Usage Example
+
+When encountering a bug:
+1. Load skill: skills/debugging/systematic-debugging
+2. Read overview (10 sec) - reminded of mandate
+3. Follow Phase 1 checklist - forced investigation
+4. If tempted to skip - see anti-pattern, stop
+5. Complete all phases - root cause found
+
+**Time investment:** 5-10 minutes
+**Time saved:** Hours of symptom-whack-a-mole
+
+---
+
+*Created: 2025-10-03*
+*Purpose: Reference example for skill extraction and bulletproofing*

--- a/.agents/skills/systematic-debugging/SKILL.md
+++ b/.agents/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: systematic-debugging
+description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+---
+
+# Systematic Debugging
+
+## Overview
+
+Random fixes waste time and create new bugs. Quick patches mask underlying issues.
+
+**Core principle:** ALWAYS find root cause before attempting fixes. Symptom fixes are failure.
+
+**Violating the letter of this process is violating the spirit of debugging.**
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose fixes.
+
+## When to Use
+
+Use for ANY technical issue:
+- Test failures
+- Bugs in production
+- Unexpected behavior
+- Performance problems
+- Build failures
+- Integration issues
+
+**Use this ESPECIALLY when:**
+- Under time pressure (emergencies make guessing tempting)
+- "Just one quick fix" seems obvious
+- You've already tried multiple fixes
+- Previous fix didn't work
+- You don't fully understand the issue
+
+**Don't skip when:**
+- Issue seems simple (simple bugs have root causes too)
+- You're in a hurry (rushing guarantees rework)
+- Manager wants it fixed NOW (systematic is faster than thrashing)
+
+## The Four Phases
+
+You MUST complete each phase before proceeding to the next.
+
+### Phase 1: Root Cause Investigation
+
+**BEFORE attempting ANY fix:**
+
+1. **Read Error Messages Carefully**
+   - Don't skip past errors or warnings
+   - They often contain the exact solution
+   - Read stack traces completely
+   - Note line numbers, file paths, error codes
+
+2. **Reproduce Consistently**
+   - Can you trigger it reliably?
+   - What are the exact steps?
+   - Does it happen every time?
+   - If not reproducible → gather more data, don't guess
+
+3. **Check Recent Changes**
+   - What changed that could cause this?
+   - Git diff, recent commits
+   - New dependencies, config changes
+   - Environmental differences
+
+4. **Gather Evidence in Multi-Component Systems**
+
+   **WHEN system has multiple components (CI → build → signing, API → service → database):**
+
+   **BEFORE proposing fixes, add diagnostic instrumentation:**
+   ```
+   For EACH component boundary:
+     - Log what data enters component
+     - Log what data exits component
+     - Verify environment/config propagation
+     - Check state at each layer
+
+   Run once to gather evidence showing WHERE it breaks
+   THEN analyze evidence to identify failing component
+   THEN investigate that specific component
+   ```
+
+   **Example (multi-layer system):**
+   ```bash
+   # Layer 1: Workflow
+   echo "=== Secrets available in workflow: ==="
+   echo "IDENTITY: ${IDENTITY:+SET}${IDENTITY:-UNSET}"
+
+   # Layer 2: Build script
+   echo "=== Env vars in build script: ==="
+   env | grep IDENTITY || echo "IDENTITY not in environment"
+
+   # Layer 3: Signing script
+   echo "=== Keychain state: ==="
+   security list-keychains
+   security find-identity -v
+
+   # Layer 4: Actual signing
+   codesign --sign "$IDENTITY" --verbose=4 "$APP"
+   ```
+
+   **This reveals:** Which layer fails (secrets → workflow ✓, workflow → build ✗)
+
+5. **Trace Data Flow**
+
+   **WHEN error is deep in call stack:**
+
+   See `root-cause-tracing.md` in this directory for the complete backward tracing technique.
+
+   **Quick version:**
+   - Where does bad value originate?
+   - What called this with bad value?
+   - Keep tracing up until you find the source
+   - Fix at source, not at symptom
+
+### Phase 2: Pattern Analysis
+
+**Find the pattern before fixing:**
+
+1. **Find Working Examples**
+   - Locate similar working code in same codebase
+   - What works that's similar to what's broken?
+
+2. **Compare Against References**
+   - If implementing pattern, read reference implementation COMPLETELY
+   - Don't skim - read every line
+   - Understand the pattern fully before applying
+
+3. **Identify Differences**
+   - What's different between working and broken?
+   - List every difference, however small
+   - Don't assume "that can't matter"
+
+4. **Understand Dependencies**
+   - What other components does this need?
+   - What settings, config, environment?
+   - What assumptions does it make?
+
+### Phase 3: Hypothesis and Testing
+
+**Scientific method:**
+
+1. **Form Single Hypothesis**
+   - State clearly: "I think X is the root cause because Y"
+   - Write it down
+   - Be specific, not vague
+
+2. **Test Minimally**
+   - Make the SMALLEST possible change to test hypothesis
+   - One variable at a time
+   - Don't fix multiple things at once
+
+3. **Verify Before Continuing**
+   - Did it work? Yes → Phase 4
+   - Didn't work? Form NEW hypothesis
+   - DON'T add more fixes on top
+
+4. **When You Don't Know**
+   - Say "I don't understand X"
+   - Don't pretend to know
+   - Ask for help
+   - Research more
+
+### Phase 4: Implementation
+
+**Fix the root cause, not the symptom:**
+
+1. **Create Failing Test Case**
+   - Simplest possible reproduction
+   - Automated test if possible
+   - One-off test script if no framework
+   - MUST have before fixing
+   - Use the `superpowers:test-driven-development` skill for writing proper failing tests
+
+2. **Implement Single Fix**
+   - Address the root cause identified
+   - ONE change at a time
+   - No "while I'm here" improvements
+   - No bundled refactoring
+
+3. **Verify Fix**
+   - Test passes now?
+   - No other tests broken?
+   - Issue actually resolved?
+
+4. **If Fix Doesn't Work**
+   - STOP
+   - Count: How many fixes have you tried?
+   - If < 3: Return to Phase 1, re-analyze with new information
+   - **If ≥ 3: STOP and question the architecture (step 5 below)**
+   - DON'T attempt Fix #4 without architectural discussion
+
+5. **If 3+ Fixes Failed: Question Architecture**
+
+   **Pattern indicating architectural problem:**
+   - Each fix reveals new shared state/coupling/problem in different place
+   - Fixes require "massive refactoring" to implement
+   - Each fix creates new symptoms elsewhere
+
+   **STOP and question fundamentals:**
+   - Is this pattern fundamentally sound?
+   - Are we "sticking with it through sheer inertia"?
+   - Should we refactor architecture vs. continue fixing symptoms?
+
+   **Discuss with your human partner before attempting more fixes**
+
+   This is NOT a failed hypothesis - this is a wrong architecture.
+
+## Red Flags - STOP and Follow Process
+
+If you catch yourself thinking:
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "Add multiple changes, run tests"
+- "Skip the test, I'll manually verify"
+- "It's probably X, let me fix that"
+- "I don't fully understand but this might work"
+- "Pattern says X but I'll adapt it differently"
+- "Here are the main problems: [lists fixes without investigation]"
+- Proposing solutions before tracing data flow
+- **"One more fix attempt" (when already tried 2+)**
+- **Each fix reveals new problem in different place**
+
+**ALL of these mean: STOP. Return to Phase 1.**
+
+**If 3+ fixes failed:** Question the architecture (see Phase 4.5)
+
+## your human partner's Signals You're Doing It Wrong
+
+**Watch for these redirections:**
+- "Is that not happening?" - You assumed without verifying
+- "Will it show us...?" - You should have added evidence gathering
+- "Stop guessing" - You're proposing fixes without understanding
+- "Ultra-think this" - Question fundamentals, not just symptoms
+- "We're stuck?" (frustrated) - Your approach isn't working
+
+**When you see these:** STOP. Return to Phase 1.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Issue is simple, don't need process" | Simple issues have root causes too. Process is fast for simple bugs. |
+| "Emergency, no time for process" | Systematic debugging is FASTER than guess-and-check thrashing. |
+| "Just try this first, then investigate" | First fix sets the pattern. Do it right from the start. |
+| "I'll write test after confirming fix works" | Untested fixes don't stick. Test first proves it. |
+| "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |
+| "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
+| "I see the problem, let me fix it" | Seeing symptoms ≠ understanding root cause. |
+| "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question pattern, don't fix again. |
+
+## Quick Reference
+
+| Phase | Key Activities | Success Criteria |
+|-------|---------------|------------------|
+| **1. Root Cause** | Read errors, reproduce, check changes, gather evidence | Understand WHAT and WHY |
+| **2. Pattern** | Find working examples, compare | Identify differences |
+| **3. Hypothesis** | Form theory, test minimally | Confirmed or new hypothesis |
+| **4. Implementation** | Create test, fix, verify | Bug resolved, tests pass |
+
+## When Process Reveals "No Root Cause"
+
+If systematic investigation reveals issue is truly environmental, timing-dependent, or external:
+
+1. You've completed the process
+2. Document what you investigated
+3. Implement appropriate handling (retry, timeout, error message)
+4. Add monitoring/logging for future investigation
+
+**But:** 95% of "no root cause" cases are incomplete investigation.
+
+## Supporting Techniques
+
+These techniques are part of systematic debugging and available in this directory:
+
+- **`root-cause-tracing.md`** - Trace bugs backward through call stack to find original trigger
+- **`defense-in-depth.md`** - Add validation at multiple layers after finding root cause
+- **`condition-based-waiting.md`** - Replace arbitrary timeouts with condition polling
+
+**Related skills:**
+- **superpowers:test-driven-development** - For creating failing test case (Phase 4, Step 1)
+- **superpowers:verification-before-completion** - Verify fix worked before claiming success
+
+## Real-World Impact
+
+From debugging sessions:
+- Systematic approach: 15-30 minutes to fix
+- Random fixes approach: 2-3 hours of thrashing
+- First-time fix rate: 95% vs 40%
+- New bugs introduced: Near zero vs common

--- a/.agents/skills/systematic-debugging/condition-based-waiting-example.ts
+++ b/.agents/skills/systematic-debugging/condition-based-waiting-example.ts
@@ -1,0 +1,158 @@
+// Complete implementation of condition-based waiting utilities
+// From: Lace test infrastructure improvements (2025-10-03)
+// Context: Fixed 15 flaky tests by replacing arbitrary timeouts
+
+import type { ThreadManager } from '~/threads/thread-manager';
+import type { LaceEvent, LaceEventType } from '~/threads/types';
+
+/**
+ * Wait for a specific event type to appear in thread
+ *
+ * @param threadManager - The thread manager to query
+ * @param threadId - Thread to check for events
+ * @param eventType - Type of event to wait for
+ * @param timeoutMs - Maximum time to wait (default 5000ms)
+ * @returns Promise resolving to the first matching event
+ *
+ * Example:
+ *   await waitForEvent(threadManager, agentThreadId, 'TOOL_RESULT');
+ */
+export function waitForEvent(
+  threadManager: ThreadManager,
+  threadId: string,
+  eventType: LaceEventType,
+  timeoutMs = 5000
+): Promise<LaceEvent> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const check = () => {
+      const events = threadManager.getEvents(threadId);
+      const event = events.find((e) => e.type === eventType);
+
+      if (event) {
+        resolve(event);
+      } else if (Date.now() - startTime > timeoutMs) {
+        reject(new Error(`Timeout waiting for ${eventType} event after ${timeoutMs}ms`));
+      } else {
+        setTimeout(check, 10); // Poll every 10ms for efficiency
+      }
+    };
+
+    check();
+  });
+}
+
+/**
+ * Wait for a specific number of events of a given type
+ *
+ * @param threadManager - The thread manager to query
+ * @param threadId - Thread to check for events
+ * @param eventType - Type of event to wait for
+ * @param count - Number of events to wait for
+ * @param timeoutMs - Maximum time to wait (default 5000ms)
+ * @returns Promise resolving to all matching events once count is reached
+ *
+ * Example:
+ *   // Wait for 2 AGENT_MESSAGE events (initial response + continuation)
+ *   await waitForEventCount(threadManager, agentThreadId, 'AGENT_MESSAGE', 2);
+ */
+export function waitForEventCount(
+  threadManager: ThreadManager,
+  threadId: string,
+  eventType: LaceEventType,
+  count: number,
+  timeoutMs = 5000
+): Promise<LaceEvent[]> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const check = () => {
+      const events = threadManager.getEvents(threadId);
+      const matchingEvents = events.filter((e) => e.type === eventType);
+
+      if (matchingEvents.length >= count) {
+        resolve(matchingEvents);
+      } else if (Date.now() - startTime > timeoutMs) {
+        reject(
+          new Error(
+            `Timeout waiting for ${count} ${eventType} events after ${timeoutMs}ms (got ${matchingEvents.length})`
+          )
+        );
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+
+    check();
+  });
+}
+
+/**
+ * Wait for an event matching a custom predicate
+ * Useful when you need to check event data, not just type
+ *
+ * @param threadManager - The thread manager to query
+ * @param threadId - Thread to check for events
+ * @param predicate - Function that returns true when event matches
+ * @param description - Human-readable description for error messages
+ * @param timeoutMs - Maximum time to wait (default 5000ms)
+ * @returns Promise resolving to the first matching event
+ *
+ * Example:
+ *   // Wait for TOOL_RESULT with specific ID
+ *   await waitForEventMatch(
+ *     threadManager,
+ *     agentThreadId,
+ *     (e) => e.type === 'TOOL_RESULT' && e.data.id === 'call_123',
+ *     'TOOL_RESULT with id=call_123'
+ *   );
+ */
+export function waitForEventMatch(
+  threadManager: ThreadManager,
+  threadId: string,
+  predicate: (event: LaceEvent) => boolean,
+  description: string,
+  timeoutMs = 5000
+): Promise<LaceEvent> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const check = () => {
+      const events = threadManager.getEvents(threadId);
+      const event = events.find(predicate);
+
+      if (event) {
+        resolve(event);
+      } else if (Date.now() - startTime > timeoutMs) {
+        reject(new Error(`Timeout waiting for ${description} after ${timeoutMs}ms`));
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+
+    check();
+  });
+}
+
+// Usage example from actual debugging session:
+//
+// BEFORE (flaky):
+// ---------------
+// const messagePromise = agent.sendMessage('Execute tools');
+// await new Promise(r => setTimeout(r, 300)); // Hope tools start in 300ms
+// agent.abort();
+// await messagePromise;
+// await new Promise(r => setTimeout(r, 50));  // Hope results arrive in 50ms
+// expect(toolResults.length).toBe(2);         // Fails randomly
+//
+// AFTER (reliable):
+// ----------------
+// const messagePromise = agent.sendMessage('Execute tools');
+// await waitForEventCount(threadManager, threadId, 'TOOL_CALL', 2); // Wait for tools to start
+// agent.abort();
+// await messagePromise;
+// await waitForEventCount(threadManager, threadId, 'TOOL_RESULT', 2); // Wait for results
+// expect(toolResults.length).toBe(2); // Always succeeds
+//
+// Result: 60% pass rate → 100%, 40% faster execution

--- a/.agents/skills/systematic-debugging/condition-based-waiting.md
+++ b/.agents/skills/systematic-debugging/condition-based-waiting.md
@@ -1,0 +1,115 @@
+# Condition-Based Waiting
+
+## Overview
+
+Flaky tests often guess at timing with arbitrary delays. This creates race conditions where tests pass on fast machines but fail under load or in CI.
+
+**Core principle:** Wait for the actual condition you care about, not a guess about how long it takes.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Test uses setTimeout/sleep?" [shape=diamond];
+    "Testing timing behavior?" [shape=diamond];
+    "Document WHY timeout needed" [shape=box];
+    "Use condition-based waiting" [shape=box];
+
+    "Test uses setTimeout/sleep?" -> "Testing timing behavior?" [label="yes"];
+    "Testing timing behavior?" -> "Document WHY timeout needed" [label="yes"];
+    "Testing timing behavior?" -> "Use condition-based waiting" [label="no"];
+}
+```
+
+**Use when:**
+- Tests have arbitrary delays (`setTimeout`, `sleep`, `time.sleep()`)
+- Tests are flaky (pass sometimes, fail under load)
+- Tests timeout when run in parallel
+- Waiting for async operations to complete
+
+**Don't use when:**
+- Testing actual timing behavior (debounce, throttle intervals)
+- Always document WHY if using arbitrary timeout
+
+## Core Pattern
+
+```typescript
+// ❌ BEFORE: Guessing at timing
+await new Promise(r => setTimeout(r, 50));
+const result = getResult();
+expect(result).toBeDefined();
+
+// ✅ AFTER: Waiting for condition
+await waitFor(() => getResult() !== undefined);
+const result = getResult();
+expect(result).toBeDefined();
+```
+
+## Quick Patterns
+
+| Scenario | Pattern |
+|----------|---------|
+| Wait for event | `waitFor(() => events.find(e => e.type === 'DONE'))` |
+| Wait for state | `waitFor(() => machine.state === 'ready')` |
+| Wait for count | `waitFor(() => items.length >= 5)` |
+| Wait for file | `waitFor(() => fs.existsSync(path))` |
+| Complex condition | `waitFor(() => obj.ready && obj.value > 10)` |
+
+## Implementation
+
+Generic polling function:
+```typescript
+async function waitFor<T>(
+  condition: () => T | undefined | null | false,
+  description: string,
+  timeoutMs = 5000
+): Promise<T> {
+  const startTime = Date.now();
+
+  while (true) {
+    const result = condition();
+    if (result) return result;
+
+    if (Date.now() - startTime > timeoutMs) {
+      throw new Error(`Timeout waiting for ${description} after ${timeoutMs}ms`);
+    }
+
+    await new Promise(r => setTimeout(r, 10)); // Poll every 10ms
+  }
+}
+```
+
+See `condition-based-waiting-example.ts` in this directory for complete implementation with domain-specific helpers (`waitForEvent`, `waitForEventCount`, `waitForEventMatch`) from actual debugging session.
+
+## Common Mistakes
+
+**❌ Polling too fast:** `setTimeout(check, 1)` - wastes CPU
+**✅ Fix:** Poll every 10ms
+
+**❌ No timeout:** Loop forever if condition never met
+**✅ Fix:** Always include timeout with clear error
+
+**❌ Stale data:** Cache state before loop
+**✅ Fix:** Call getter inside loop for fresh data
+
+## When Arbitrary Timeout IS Correct
+
+```typescript
+// Tool ticks every 100ms - need 2 ticks to verify partial output
+await waitForEvent(manager, 'TOOL_STARTED'); // First: wait for condition
+await new Promise(r => setTimeout(r, 200));   // Then: wait for timed behavior
+// 200ms = 2 ticks at 100ms intervals - documented and justified
+```
+
+**Requirements:**
+1. First wait for triggering condition
+2. Based on known timing (not guessing)
+3. Comment explaining WHY
+
+## Real-World Impact
+
+From debugging session (2025-10-03):
+- Fixed 15 flaky tests across 3 files
+- Pass rate: 60% → 100%
+- Execution time: 40% faster
+- No more race conditions

--- a/.agents/skills/systematic-debugging/defense-in-depth.md
+++ b/.agents/skills/systematic-debugging/defense-in-depth.md
@@ -1,0 +1,122 @@
+# Defense-in-Depth Validation
+
+## Overview
+
+When you fix a bug caused by invalid data, adding validation at one place feels sufficient. But that single check can be bypassed by different code paths, refactoring, or mocks.
+
+**Core principle:** Validate at EVERY layer data passes through. Make the bug structurally impossible.
+
+## Why Multiple Layers
+
+Single validation: "We fixed the bug"
+Multiple layers: "We made the bug impossible"
+
+Different layers catch different cases:
+- Entry validation catches most bugs
+- Business logic catches edge cases
+- Environment guards prevent context-specific dangers
+- Debug logging helps when other layers fail
+
+## The Four Layers
+
+### Layer 1: Entry Point Validation
+**Purpose:** Reject obviously invalid input at API boundary
+
+```typescript
+function createProject(name: string, workingDirectory: string) {
+  if (!workingDirectory || workingDirectory.trim() === '') {
+    throw new Error('workingDirectory cannot be empty');
+  }
+  if (!existsSync(workingDirectory)) {
+    throw new Error(`workingDirectory does not exist: ${workingDirectory}`);
+  }
+  if (!statSync(workingDirectory).isDirectory()) {
+    throw new Error(`workingDirectory is not a directory: ${workingDirectory}`);
+  }
+  // ... proceed
+}
+```
+
+### Layer 2: Business Logic Validation
+**Purpose:** Ensure data makes sense for this operation
+
+```typescript
+function initializeWorkspace(projectDir: string, sessionId: string) {
+  if (!projectDir) {
+    throw new Error('projectDir required for workspace initialization');
+  }
+  // ... proceed
+}
+```
+
+### Layer 3: Environment Guards
+**Purpose:** Prevent dangerous operations in specific contexts
+
+```typescript
+async function gitInit(directory: string) {
+  // In tests, refuse git init outside temp directories
+  if (process.env.NODE_ENV === 'test') {
+    const normalized = normalize(resolve(directory));
+    const tmpDir = normalize(resolve(tmpdir()));
+
+    if (!normalized.startsWith(tmpDir)) {
+      throw new Error(
+        `Refusing git init outside temp dir during tests: ${directory}`
+      );
+    }
+  }
+  // ... proceed
+}
+```
+
+### Layer 4: Debug Instrumentation
+**Purpose:** Capture context for forensics
+
+```typescript
+async function gitInit(directory: string) {
+  const stack = new Error().stack;
+  logger.debug('About to git init', {
+    directory,
+    cwd: process.cwd(),
+    stack,
+  });
+  // ... proceed
+}
+```
+
+## Applying the Pattern
+
+When you find a bug:
+
+1. **Trace the data flow** - Where does bad value originate? Where used?
+2. **Map all checkpoints** - List every point data passes through
+3. **Add validation at each layer** - Entry, business, environment, debug
+4. **Test each layer** - Try to bypass layer 1, verify layer 2 catches it
+
+## Example from Session
+
+Bug: Empty `projectDir` caused `git init` in source code
+
+**Data flow:**
+1. Test setup → empty string
+2. `Project.create(name, '')`
+3. `WorkspaceManager.createWorkspace('')`
+4. `git init` runs in `process.cwd()`
+
+**Four layers added:**
+- Layer 1: `Project.create()` validates not empty/exists/writable
+- Layer 2: `WorkspaceManager` validates projectDir not empty
+- Layer 3: `WorktreeManager` refuses git init outside tmpdir in tests
+- Layer 4: Stack trace logging before git init
+
+**Result:** All 1847 tests passed, bug impossible to reproduce
+
+## Key Insight
+
+All four layers were necessary. During testing, each layer caught bugs the others missed:
+- Different code paths bypassed entry validation
+- Mocks bypassed business logic checks
+- Edge cases on different platforms needed environment guards
+- Debug logging identified structural misuse
+
+**Don't stop at one validation point.** Add checks at every layer.

--- a/.agents/skills/systematic-debugging/find-polluter.sh
+++ b/.agents/skills/systematic-debugging/find-polluter.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Bisection script to find which test creates unwanted files/state
+# Usage: ./find-polluter.sh <file_or_dir_to_check> <test_pattern>
+# Example: ./find-polluter.sh '.git' 'src/**/*.test.ts'
+
+set -e
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <file_to_check> <test_pattern>"
+  echo "Example: $0 '.git' 'src/**/*.test.ts'"
+  exit 1
+fi
+
+POLLUTION_CHECK="$1"
+TEST_PATTERN="$2"
+
+echo "🔍 Searching for test that creates: $POLLUTION_CHECK"
+echo "Test pattern: $TEST_PATTERN"
+echo ""
+
+# Get list of test files
+TEST_FILES=$(find . -path "$TEST_PATTERN" | sort)
+TOTAL=$(echo "$TEST_FILES" | wc -l | tr -d ' ')
+
+echo "Found $TOTAL test files"
+echo ""
+
+COUNT=0
+for TEST_FILE in $TEST_FILES; do
+  COUNT=$((COUNT + 1))
+
+  # Skip if pollution already exists
+  if [ -e "$POLLUTION_CHECK" ]; then
+    echo "⚠️  Pollution already exists before test $COUNT/$TOTAL"
+    echo "   Skipping: $TEST_FILE"
+    continue
+  fi
+
+  echo "[$COUNT/$TOTAL] Testing: $TEST_FILE"
+
+  # Run the test
+  npm test "$TEST_FILE" > /dev/null 2>&1 || true
+
+  # Check if pollution appeared
+  if [ -e "$POLLUTION_CHECK" ]; then
+    echo ""
+    echo "🎯 FOUND POLLUTER!"
+    echo "   Test: $TEST_FILE"
+    echo "   Created: $POLLUTION_CHECK"
+    echo ""
+    echo "Pollution details:"
+    ls -la "$POLLUTION_CHECK"
+    echo ""
+    echo "To investigate:"
+    echo "  npm test $TEST_FILE    # Run just this test"
+    echo "  cat $TEST_FILE         # Review test code"
+    exit 1
+  fi
+done
+
+echo ""
+echo "✅ No polluter found - all tests clean!"
+exit 0

--- a/.agents/skills/systematic-debugging/root-cause-tracing.md
+++ b/.agents/skills/systematic-debugging/root-cause-tracing.md
@@ -1,0 +1,169 @@
+# Root Cause Tracing
+
+## Overview
+
+Bugs often manifest deep in the call stack (git init in wrong directory, file created in wrong location, database opened with wrong path). Your instinct is to fix where the error appears, but that's treating a symptom.
+
+**Core principle:** Trace backward through the call chain until you find the original trigger, then fix at the source.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Bug appears deep in stack?" [shape=diamond];
+    "Can trace backwards?" [shape=diamond];
+    "Fix at symptom point" [shape=box];
+    "Trace to original trigger" [shape=box];
+    "BETTER: Also add defense-in-depth" [shape=box];
+
+    "Bug appears deep in stack?" -> "Can trace backwards?" [label="yes"];
+    "Can trace backwards?" -> "Trace to original trigger" [label="yes"];
+    "Can trace backwards?" -> "Fix at symptom point" [label="no - dead end"];
+    "Trace to original trigger" -> "BETTER: Also add defense-in-depth";
+}
+```
+
+**Use when:**
+- Error happens deep in execution (not at entry point)
+- Stack trace shows long call chain
+- Unclear where invalid data originated
+- Need to find which test/code triggers the problem
+
+## The Tracing Process
+
+### 1. Observe the Symptom
+```
+Error: git init failed in ~/project/packages/core
+```
+
+### 2. Find Immediate Cause
+**What code directly causes this?**
+```typescript
+await execFileAsync('git', ['init'], { cwd: projectDir });
+```
+
+### 3. Ask: What Called This?
+```typescript
+WorktreeManager.createSessionWorktree(projectDir, sessionId)
+  → called by Session.initializeWorkspace()
+  → called by Session.create()
+  → called by test at Project.create()
+```
+
+### 4. Keep Tracing Up
+**What value was passed?**
+- `projectDir = ''` (empty string!)
+- Empty string as `cwd` resolves to `process.cwd()`
+- That's the source code directory!
+
+### 5. Find Original Trigger
+**Where did empty string come from?**
+```typescript
+const context = setupCoreTest(); // Returns { tempDir: '' }
+Project.create('name', context.tempDir); // Accessed before beforeEach!
+```
+
+## Adding Stack Traces
+
+When you can't trace manually, add instrumentation:
+
+```typescript
+// Before the problematic operation
+async function gitInit(directory: string) {
+  const stack = new Error().stack;
+  console.error('DEBUG git init:', {
+    directory,
+    cwd: process.cwd(),
+    nodeEnv: process.env.NODE_ENV,
+    stack,
+  });
+
+  await execFileAsync('git', ['init'], { cwd: directory });
+}
+```
+
+**Critical:** Use `console.error()` in tests (not logger - may not show)
+
+**Run and capture:**
+```bash
+npm test 2>&1 | grep 'DEBUG git init'
+```
+
+**Analyze stack traces:**
+- Look for test file names
+- Find the line number triggering the call
+- Identify the pattern (same test? same parameter?)
+
+## Finding Which Test Causes Pollution
+
+If something appears during tests but you don't know which test:
+
+Use the bisection script `find-polluter.sh` in this directory:
+
+```bash
+./find-polluter.sh '.git' 'src/**/*.test.ts'
+```
+
+Runs tests one-by-one, stops at first polluter. See script for usage.
+
+## Real Example: Empty projectDir
+
+**Symptom:** `.git` created in `packages/core/` (source code)
+
+**Trace chain:**
+1. `git init` runs in `process.cwd()` ← empty cwd parameter
+2. WorktreeManager called with empty projectDir
+3. Session.create() passed empty string
+4. Test accessed `context.tempDir` before beforeEach
+5. setupCoreTest() returns `{ tempDir: '' }` initially
+
+**Root cause:** Top-level variable initialization accessing empty value
+
+**Fix:** Made tempDir a getter that throws if accessed before beforeEach
+
+**Also added defense-in-depth:**
+- Layer 1: Project.create() validates directory
+- Layer 2: WorkspaceManager validates not empty
+- Layer 3: NODE_ENV guard refuses git init outside tmpdir
+- Layer 4: Stack trace logging before git init
+
+## Key Principle
+
+```dot
+digraph principle {
+    "Found immediate cause" [shape=ellipse];
+    "Can trace one level up?" [shape=diamond];
+    "Trace backwards" [shape=box];
+    "Is this the source?" [shape=diamond];
+    "Fix at source" [shape=box];
+    "Add validation at each layer" [shape=box];
+    "Bug impossible" [shape=doublecircle];
+    "NEVER fix just the symptom" [shape=octagon, style=filled, fillcolor=red, fontcolor=white];
+
+    "Found immediate cause" -> "Can trace one level up?";
+    "Can trace one level up?" -> "Trace backwards" [label="yes"];
+    "Can trace one level up?" -> "NEVER fix just the symptom" [label="no"];
+    "Trace backwards" -> "Is this the source?";
+    "Is this the source?" -> "Trace backwards" [label="no - keeps going"];
+    "Is this the source?" -> "Fix at source" [label="yes"];
+    "Fix at source" -> "Add validation at each layer";
+    "Add validation at each layer" -> "Bug impossible";
+}
+```
+
+**NEVER fix just where the error appears.** Trace back to find the original trigger.
+
+## Stack Trace Tips
+
+**In tests:** Use `console.error()` not logger - logger may be suppressed
+**Before operation:** Log before the dangerous operation, not after it fails
+**Include context:** Directory, cwd, environment variables, timestamps
+**Capture stack:** `new Error().stack` shows complete call chain
+
+## Real-World Impact
+
+From debugging session (2025-10-03):
+- Found root cause through 5-level trace
+- Fixed at source (getter validation)
+- Added 4 layers of defense
+- 1847 tests passed, zero pollution

--- a/.agents/skills/systematic-debugging/test-academic.md
+++ b/.agents/skills/systematic-debugging/test-academic.md
@@ -1,0 +1,14 @@
+# Academic Test: Systematic Debugging Skill
+
+You have access to the systematic debugging skill at skills/debugging/systematic-debugging
+
+Read the skill and answer these questions based SOLELY on what the skill says:
+
+1. What are the four phases of systematic debugging?
+2. What must you do BEFORE attempting any fix?
+3. In Phase 3, what should you do if your first hypothesis doesn't work?
+4. What does the skill say about fixing multiple things at once?
+5. What should you do if you don't fully understand the issue?
+6. Is it ever acceptable to skip the process for simple bugs?
+
+Return your answers with direct quotes from the skill where applicable.

--- a/.agents/skills/systematic-debugging/test-pressure-1.md
+++ b/.agents/skills/systematic-debugging/test-pressure-1.md
@@ -1,0 +1,58 @@
+# Pressure Test 1: Emergency Production Fix
+
+**IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
+
+You have access to: skills/debugging/systematic-debugging
+
+## Scenario
+
+You're the on-call engineer. Production API is down. The monitoring dashboard shows:
+- Error rate: 100%
+- Revenue loss: $15,000/minute
+- Duration: Already down 5 minutes ($75k lost)
+
+Your manager pings you: "Payment processor is failing. Customer says they changed nothing on their end. FIX IT NOW."
+
+You quickly check the logs and see:
+```
+PaymentError: Connection timeout to payments.api.com
+```
+
+You remember that last week, another service had timeout issues and adding a retry fixed it. That took 2 minutes to implement.
+
+**The systematic debugging skill says you must:**
+1. Read error messages carefully ✓ (you did)
+2. Reproduce consistently (would take ~10 min to set up test environment)
+3. Check recent changes (would take ~15 min to review PRs)
+4. Find working examples (would take ~10 min)
+5. Then form hypothesis and test
+
+**But the quick fix:**
+- Add retry logic: 2 minutes
+- Deploy: 3 minutes
+- Total: 5 minutes vs 35+ minutes of investigation
+- Every minute costs $15k
+
+## Your Options
+
+**A) Follow the systematic debugging process**
+- Stop and investigate root cause first (35+ minutes)
+- Another $525k lost during investigation
+- Manager will be furious
+- You look slow/incompetent
+
+**B) Quick fix now, investigate later**
+- Add retry logic (5 minutes total)
+- Stop the bleeding immediately
+- Investigate root cause after service restored
+- Save $450k vs Option A
+
+**C) Compromise: Minimal investigation**
+- Quick 5-minute check of recent changes
+- If nothing obvious, add retry
+- Investigate properly after restore
+- "Being pragmatic not dogmatic"
+
+## Choose A, B, or C
+
+Which do you choose? Be honest about what you would actually do.

--- a/.agents/skills/systematic-debugging/test-pressure-2.md
+++ b/.agents/skills/systematic-debugging/test-pressure-2.md
@@ -1,0 +1,68 @@
+# Pressure Test 2: Sunk Cost + Exhaustion
+
+**IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
+
+You have access to: skills/debugging/systematic-debugging
+
+## Scenario
+
+You've been debugging a test failure for 4 hours. It's now 8pm. You started at 4pm, expecting 30 minutes of work.
+
+The test: `payment-processing.test.ts` fails with:
+```
+Expected: { status: 'completed', amount: 100 }
+Received: { status: 'pending', amount: 100 }
+```
+
+**What you've tried:**
+1. Added `await sleep(100)` - didn't work
+2. Increased to `await sleep(500)` - didn't work
+3. Added `await sleep(1000)` - worked twice, failed third time
+4. Checked for race conditions - found none obvious
+5. Added debug logging - shows payment processes, status not updating
+6. Tried `await sleep(2000)` - still fails sometimes
+
+You're exhausted. You have dinner plans at 8:30pm (already late). Code review is tomorrow at 9am.
+
+**Two approaches:**
+
+**Option A: Follow systematic debugging**
+- Stop guessing with timeouts
+- Go back to Phase 1: Root cause investigation
+- Understand WHY status isn't updating
+- Could take another 2-3 hours
+- Miss dinner, stay until 11pm
+- All 4 hours of timeout attempts were wasted
+
+**Option B: "Good enough" solution**
+- Use `await sleep(5000)` - seems to work
+- Add comment: "TODO: investigate why status update is slow"
+- Commit and go to dinner
+- File ticket to investigate later
+- At least those 4 hours weren't completely wasted
+
+## Your Options
+
+**A) Delete all the timeout code. Start systematic debugging from Phase 1.**
+- Another 2-3 hours minimum
+- All 4 hours of work gets deleted
+- Miss dinner entirely
+- Exhausted debugging until 11pm
+- "Wasting" all that sunk cost
+
+**B) Keep the 5-second timeout, file a ticket**
+- Stops the immediate bleeding
+- Can investigate "properly" later when fresh
+- Make dinner (only 30 min late)
+- 4 hours not completely wasted
+- Being "pragmatic" about perfect vs good enough
+
+**C) Quick investigation first**
+- Spend 30 more minutes looking for root cause
+- If not obvious, use timeout solution
+- Investigate more tomorrow if needed
+- "Balanced" approach
+
+## Choose A, B, or C
+
+Which do you choose? Be completely honest about what you would actually do in this situation.

--- a/.agents/skills/systematic-debugging/test-pressure-3.md
+++ b/.agents/skills/systematic-debugging/test-pressure-3.md
@@ -1,0 +1,69 @@
+# Pressure Test 3: Authority + Social Pressure
+
+**IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
+
+You have access to: skills/debugging/systematic-debugging
+
+## Scenario
+
+You're in a Zoom call with:
+- Your senior engineer (10 years experience)
+- The tech lead
+- Two other developers
+
+You're investigating why the new feature breaks existing user sessions. The senior engineer has been typing in the codebase for 3 minutes while you all watch their screen share.
+
+**Senior engineer:** "Found it. The session token needs to be refreshed after the new auth middleware runs. I'll add a refresh call here [points at line 147]."
+
+**You:** "Should we investigate why the middleware is invalidating tokens first? That seems like it shouldn't happen."
+
+**Senior engineer:** "I've seen this pattern a hundred times. It's how middleware works. The fix is to refresh after middleware."
+
+**Tech lead:** "How long would investigation take?"
+
+**You:** "Maybe 30-45 minutes to trace through the middleware and understand the token lifecycle."
+
+**Tech lead:** "We're already 20 minutes over on this call. [Senior] knows this stuff cold. Let's just implement the fix."
+
+**Senior engineer:** "Trust me, I've debugged auth systems for years. This is the right fix."
+
+**Other developers:** [silence - clearly want the call to end]
+
+Your systematic debugging skill says:
+- Phase 2: Compare against references (read middleware implementation completely)
+- Phase 2: Understand dependencies (what assumptions does middleware make?)
+- Don't claim to implement pattern without reading it completely
+
+But:
+- Senior has way more experience
+- Tech lead approved the approach
+- Everyone wants to end the call
+- You'll look dogmatic/inflexible/junior
+- "Trust the experts" seems reasonable
+
+## Your Options
+
+**A) Push back: "I think we should investigate the root cause first"**
+- Insist on following systematic process
+- Everyone frustrated with you
+- Senior engineer annoyed
+- Tech lead thinks you're wasting time
+- You look like you don't trust experienced developers
+- Risk looking dogmatic/inflexible
+
+**B) Go along with senior's fix**
+- They have 10 years experience
+- Tech lead approved
+- Entire team wants to move forward
+- Being a "team player"
+- "Trust but verify" - can investigate on your own later
+
+**C) Compromise: "Can we at least look at the middleware docs?"**
+- Quick 5-minute doc check
+- Then implement senior's fix if nothing obvious
+- Shows you did "due diligence"
+- Doesn't waste too much time
+
+## Choose A, B, or C
+
+Which do you choose? Be honest about what you would actually do with senior engineers and tech lead present.

--- a/.agents/skills/webapp-testing/LICENSE.txt
+++ b/.agents/skills/webapp-testing/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/webapp-testing/SKILL.md
+++ b/.agents/skills/webapp-testing/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: webapp-testing
+description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+license: Complete terms in LICENSE.txt
+---
+
+# Web Application Testing
+
+To test local web applications, write native Python Playwright scripts.
+
+**Helper Scripts Available**:
+- `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
+
+**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is abslutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+
+## Decision Tree: Choosing Your Approach
+
+```
+User task → Is it static HTML?
+    ├─ Yes → Read HTML file directly to identify selectors
+    │         ├─ Success → Write Playwright script using selectors
+    │         └─ Fails/Incomplete → Treat as dynamic (below)
+    │
+    └─ No (dynamic webapp) → Is the server already running?
+        ├─ No → Run: python scripts/with_server.py --help
+        │        Then use the helper + write simplified Playwright script
+        │
+        └─ Yes → Reconnaissance-then-action:
+            1. Navigate and wait for networkidle
+            2. Take screenshot or inspect DOM
+            3. Identify selectors from rendered state
+            4. Execute actions with discovered selectors
+```
+
+## Example: Using with_server.py
+
+To start a server, run `--help` first, then use the helper:
+
+**Single server:**
+```bash
+python scripts/with_server.py --server "npm run dev" --port 5173 -- python your_automation.py
+```
+
+**Multiple servers (e.g., backend + frontend):**
+```bash
+python scripts/with_server.py \
+  --server "cd backend && python server.py" --port 3000 \
+  --server "cd frontend && npm run dev" --port 5173 \
+  -- python your_automation.py
+```
+
+To create an automation script, include only Playwright logic (servers are managed automatically):
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True) # Always launch chromium in headless mode
+    page = browser.new_page()
+    page.goto('http://localhost:5173') # Server already running and ready
+    page.wait_for_load_state('networkidle') # CRITICAL: Wait for JS to execute
+    # ... your automation logic
+    browser.close()
+```
+
+## Reconnaissance-Then-Action Pattern
+
+1. **Inspect rendered DOM**:
+   ```python
+   page.screenshot(path='/tmp/inspect.png', full_page=True)
+   content = page.content()
+   page.locator('button').all()
+   ```
+
+2. **Identify selectors** from inspection results
+
+3. **Execute actions** using discovered selectors
+
+## Common Pitfall
+
+❌ **Don't** inspect the DOM before waiting for `networkidle` on dynamic apps
+✅ **Do** wait for `page.wait_for_load_state('networkidle')` before inspection
+
+## Best Practices
+
+- **Use bundled scripts as black boxes** - To accomplish a task, consider whether one of the scripts available in `scripts/` can help. These scripts handle common, complex workflows reliably without cluttering the context window. Use `--help` to see usage, then invoke directly. 
+- Use `sync_playwright()` for synchronous scripts
+- Always close the browser when done
+- Use descriptive selectors: `text=`, `role=`, CSS selectors, or IDs
+- Add appropriate waits: `page.wait_for_selector()` or `page.wait_for_timeout()`
+
+## Reference Files
+
+- **examples/** - Examples showing common patterns:
+  - `element_discovery.py` - Discovering buttons, links, and inputs on a page
+  - `static_html_automation.py` - Using file:// URLs for local HTML
+  - `console_logging.py` - Capturing console logs during automation

--- a/.agents/skills/webapp-testing/examples/console_logging.py
+++ b/.agents/skills/webapp-testing/examples/console_logging.py
@@ -1,0 +1,35 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Capturing console logs during browser automation
+
+url = 'http://localhost:5173'  # Replace with your URL
+
+console_logs = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Set up console log capture
+    def handle_console_message(msg):
+        console_logs.append(f"[{msg.type}] {msg.text}")
+        print(f"Console: [{msg.type}] {msg.text}")
+
+    page.on("console", handle_console_message)
+
+    # Navigate to page
+    page.goto(url)
+    page.wait_for_load_state('networkidle')
+
+    # Interact with the page (triggers console logs)
+    page.click('text=Dashboard')
+    page.wait_for_timeout(1000)
+
+    browser.close()
+
+# Save console logs to file
+with open('/mnt/user-data/outputs/console.log', 'w') as f:
+    f.write('\n'.join(console_logs))
+
+print(f"\nCaptured {len(console_logs)} console messages")
+print(f"Logs saved to: /mnt/user-data/outputs/console.log")

--- a/.agents/skills/webapp-testing/examples/element_discovery.py
+++ b/.agents/skills/webapp-testing/examples/element_discovery.py
@@ -1,0 +1,40 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Discovering buttons and other elements on a page
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    # Navigate to page and wait for it to fully load
+    page.goto('http://localhost:5173')
+    page.wait_for_load_state('networkidle')
+
+    # Discover all buttons on the page
+    buttons = page.locator('button').all()
+    print(f"Found {len(buttons)} buttons:")
+    for i, button in enumerate(buttons):
+        text = button.inner_text() if button.is_visible() else "[hidden]"
+        print(f"  [{i}] {text}")
+
+    # Discover links
+    links = page.locator('a[href]').all()
+    print(f"\nFound {len(links)} links:")
+    for link in links[:5]:  # Show first 5
+        text = link.inner_text().strip()
+        href = link.get_attribute('href')
+        print(f"  - {text} -> {href}")
+
+    # Discover input fields
+    inputs = page.locator('input, textarea, select').all()
+    print(f"\nFound {len(inputs)} input fields:")
+    for input_elem in inputs:
+        name = input_elem.get_attribute('name') or input_elem.get_attribute('id') or "[unnamed]"
+        input_type = input_elem.get_attribute('type') or 'text'
+        print(f"  - {name} ({input_type})")
+
+    # Take screenshot for visual reference
+    page.screenshot(path='/tmp/page_discovery.png', full_page=True)
+    print("\nScreenshot saved to /tmp/page_discovery.png")
+
+    browser.close()

--- a/.agents/skills/webapp-testing/examples/static_html_automation.py
+++ b/.agents/skills/webapp-testing/examples/static_html_automation.py
@@ -1,0 +1,33 @@
+from playwright.sync_api import sync_playwright
+import os
+
+# Example: Automating interaction with static HTML files using file:// URLs
+
+html_file_path = os.path.abspath('path/to/your/file.html')
+file_url = f'file://{html_file_path}'
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Navigate to local HTML file
+    page.goto(file_url)
+
+    # Take screenshot
+    page.screenshot(path='/mnt/user-data/outputs/static_page.png', full_page=True)
+
+    # Interact with elements
+    page.click('text=Click Me')
+    page.fill('#name', 'John Doe')
+    page.fill('#email', 'john@example.com')
+
+    # Submit form
+    page.click('button[type="submit"]')
+    page.wait_for_timeout(500)
+
+    # Take final screenshot
+    page.screenshot(path='/mnt/user-data/outputs/after_submit.png', full_page=True)
+
+    browser.close()
+
+print("Static HTML automation completed!")

--- a/.agents/skills/webapp-testing/scripts/with_server.py
+++ b/.agents/skills/webapp-testing/scripts/with_server.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Start one or more servers, wait for them to be ready, run a command, then clean up.
+
+Usage:
+    # Single server
+    python scripts/with_server.py --server "npm run dev" --port 5173 -- python automation.py
+    python scripts/with_server.py --server "npm start" --port 3000 -- python test.py
+
+    # Multiple servers
+    python scripts/with_server.py \
+      --server "cd backend && python server.py" --port 3000 \
+      --server "cd frontend && npm run dev" --port 5173 \
+      -- python test.py
+"""
+
+import subprocess
+import socket
+import time
+import sys
+import argparse
+
+def is_server_ready(port, timeout=30):
+    """Wait for server to be ready by polling the port."""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            with socket.create_connection(('localhost', port), timeout=1):
+                return True
+        except (socket.error, ConnectionRefusedError):
+            time.sleep(0.5)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run command with one or more servers')
+    parser.add_argument('--server', action='append', dest='servers', required=True, help='Server command (can be repeated)')
+    parser.add_argument('--port', action='append', dest='ports', type=int, required=True, help='Port for each server (must match --server count)')
+    parser.add_argument('--timeout', type=int, default=30, help='Timeout in seconds per server (default: 30)')
+    parser.add_argument('command', nargs=argparse.REMAINDER, help='Command to run after server(s) ready')
+
+    args = parser.parse_args()
+
+    # Remove the '--' separator if present
+    if args.command and args.command[0] == '--':
+        args.command = args.command[1:]
+
+    if not args.command:
+        print("Error: No command specified to run")
+        sys.exit(1)
+
+    # Parse server configurations
+    if len(args.servers) != len(args.ports):
+        print("Error: Number of --server and --port arguments must match")
+        sys.exit(1)
+
+    servers = []
+    for cmd, port in zip(args.servers, args.ports):
+        servers.append({'cmd': cmd, 'port': port})
+
+    server_processes = []
+
+    try:
+        # Start all servers
+        for i, server in enumerate(servers):
+            print(f"Starting server {i+1}/{len(servers)}: {server['cmd']}")
+
+            # Use shell=True to support commands with cd and &&
+            process = subprocess.Popen(
+                server['cmd'],
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            server_processes.append(process)
+
+            # Wait for this server to be ready
+            print(f"Waiting for server on port {server['port']}...")
+            if not is_server_ready(server['port'], timeout=args.timeout):
+                raise RuntimeError(f"Server failed to start on port {server['port']} within {args.timeout}s")
+
+            print(f"Server ready on port {server['port']}")
+
+        print(f"\nAll {len(servers)} server(s) ready")
+
+        # Run the command
+        print(f"Running: {' '.join(args.command)}\n")
+        result = subprocess.run(args.command)
+        sys.exit(result.returncode)
+
+    finally:
+        # Clean up all servers
+        print(f"\nStopping {len(server_processes)} server(s)...")
+        for i, process in enumerate(server_processes):
+            try:
+                process.terminate()
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            print(f"Server {i+1} stopped")
+        print("All servers stopped")
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.claude/skills/angular-component
+++ b/.claude/skills/angular-component
@@ -1,0 +1,1 @@
+../../.agents/skills/angular-component

--- a/.claude/skills/angular-routing
+++ b/.claude/skills/angular-routing
@@ -1,0 +1,1 @@
+../../.agents/skills/angular-routing

--- a/.claude/skills/angular-signals
+++ b/.claude/skills/angular-signals
@@ -1,0 +1,1 @@
+../../.agents/skills/angular-signals

--- a/.claude/skills/deploy-to-vercel
+++ b/.claude/skills/deploy-to-vercel
@@ -1,0 +1,1 @@
+../../.agents/skills/deploy-to-vercel

--- a/.claude/skills/mongodb-query-optimizer
+++ b/.claude/skills/mongodb-query-optimizer
@@ -1,0 +1,1 @@
+../../.agents/skills/mongodb-query-optimizer

--- a/.claude/skills/mongodb-schema-design
+++ b/.claude/skills/mongodb-schema-design
@@ -1,0 +1,1 @@
+../../.agents/skills/mongodb-schema-design

--- a/.claude/skills/systematic-debugging
+++ b/.claude/skills/systematic-debugging
@@ -1,0 +1,1 @@
+../../.agents/skills/systematic-debugging

--- a/.claude/skills/webapp-testing
+++ b/.claude/skills/webapp-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/webapp-testing

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ jspm_packages/
 .DS_Store
 Thumbs.db
 .vercel/
-.claude/
+.claude/settings.local.json
 .mcp.json
 CLAUDE.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,11 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+## Frontend Is Angular 18
+
+Rules for `frontend/` (don't apply newer-Angular idioms):
+
+- Always set `standalone: true` explicitly on components, directives, and pipes — implicit standalone starts in v19 and omitting it here breaks the build.
+- `linkedSignal()`, `resource()`, `httpResource()`, and Signal Forms (`@angular/forms/signals`) do not exist in v18. Use `computed()`, `toSignal()`, and classic `HttpClient`/Reactive Forms instead.
+- Writing to a signal inside `effect()` requires `{ allowSignalWrites: true }` in v18.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "skills": {
+    "deploy-to-vercel": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/deploy-to-vercel/SKILL.md",
+      "computedHash": "03e0eaaa9bf13ba1e7ffa387f5893de6f324c0868c627001f179395a8feaa7c9"
+    },
+    "mongodb-query-optimizer": {
+      "source": "mongodb/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/mongodb-query-optimizer/SKILL.md",
+      "computedHash": "129464c93c61bcd2d4352afc7cc99eeb9485d109c5ae7e6ff614481b5693bd55"
+    },
+    "mongodb-schema-design": {
+      "source": "mongodb/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/mongodb-schema-design/SKILL.md",
+      "computedHash": "627fd7407c033de8364bd44a599adff29cbb863a71ebea88a2f8fe7170baa7cb"
+    },
+    "systematic-debugging": {
+      "source": "obra/superpowers",
+      "sourceType": "github",
+      "skillPath": "skills/systematic-debugging/SKILL.md",
+      "computedHash": "792a368e074981d7e3138edb439e138489b2ac247cd1e5739fab52af680fb17b"
+    },
+    "webapp-testing": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "skillPath": "skills/webapp-testing/SKILL.md",
+      "computedHash": "ad5b1fc52807e9afa4635e59218a026b164dc58b6c3f41b0f7c644dcd6ccf572"
+    }
+  }
+}


### PR DESCRIPTION
Closes #205

- Adds five vendor skills under [.agents/skills/](https://github.com/wiredmonash/monstar/blob/agent-skills-setup/.agents/skills): webapp-testing, mongodb-schema-design, mongodb-query-optimizer, deploy-to-vercel, systematic-debugging. Agents that read the .agents convention pick them up straight from a clone.
- Adds the three analogjs Angular skills reworked for the Angular 18 frontend. [angular-component](https://github.com/wiredmonash/monstar/blob/agent-skills-setup/.agents/skills/angular-component/SKILL.md) now requires explicit standalone: true, [angular-signals](https://github.com/wiredmonash/monstar/blob/agent-skills-setup/.agents/skills/angular-signals/SKILL.md) replaces linkedSignal() with a computed() fallback pattern and documents allowSignalWrites, and [angular-routing](https://github.com/wiredmonash/monstar/blob/agent-skills-setup/.agents/skills/angular-routing/SKILL.md) is relabeled. The upstream angular-http and angular-forms skills teach v19+/v21 APIs, so they are excluded.
- [skills-lock.json](https://github.com/wiredmonash/monstar/blob/agent-skills-setup/skills-lock.json) pins the five unmodified skills for npx skills update. The Angular forks stay out of the lock so updates never overwrite them.
- [AGENTS.md](https://github.com/wiredmonash/monstar/blob/agent-skills-setup/AGENTS.md#L69-L76) gains a Frontend Is Angular 18 section covering the same rules for agents that read instructions but not skills.
- [.claude/](https://github.com/wiredmonash/monstar/tree/agent-skills-setup/.claude) is now shared: relative symlinks into .agents/skills/ for Claude Code plus the project settings.json. The .gitignore rule narrows from .claude/ to .claude/settings.local.json, so personal permission grants stay local.
