### PR TITLE
Remove dead v1 frontend service methods

### DIFF
--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Types } from 'mongoose';
 import { Observable, tap } from 'rxjs';
@@ -23,54 +23,6 @@ export class ApiService {
 
   // ! Inject HttpClient
   constructor(private http: HttpClient) {}
-
-  /**
-   * * GET Get All Reviews
-   *
-   * Retrieves all reviews or reviews for a specific unit if unit code is provided.
-   *
-   * If the unit parameter is provided, we get all reviews by unit, if not get all the reviews.
-   *
-   * @param {string} [unitcode] The unit code of the unit (optional)
-   * @returns {Observable<any>} An observable containing the reviews data
-   */
-  getAllReviewsGET(unitcode?: string): Observable<any> {
-    return this.http
-      .get(unitcode ? `${this.url}/reviews/${unitcode}` : `${this.url}/reviews`)
-      .pipe(
-        tap({
-          next: (response) => {
-            // ? Debug log
-            // console.log('ApiService | Successfully fetched reviews:', response);
-          },
-          error: (error) => {
-            // ? Debug log
-            // console.log('ApiService | Error whilst fetching reviews:', error.error);
-          },
-        })
-      );
-  }
-
-  /**
-   * * GET Gets the reviews written by a user
-   *
-   * Retrieves all reviews written by a specific user.
-   *
-   * @param {string} userId The ID of the user
-   * @returns {Observable<any>} An observable containing the reviews data
-   */
-  getUserReviewsGET(userId: string): Observable<any> {
-    return this.http.get(`${this.url}/reviews/user/${userId}`).pipe(
-      tap({
-        next: (response) => {
-          // console.log('ApiService | Successfully fetched user reviews:', response);
-        },
-        error: (error) => {
-          // console.log('ApiService | Error whilst fetching user reviews:', error.error);
-        },
-      })
-    );
-  }
 
   /**
    * * GET Gets the notifications of a user
@@ -110,37 +62,6 @@ export class ApiService {
   }
 
   /**
-   * * PATCH Toggle a reaction (like or dislike) on a review
-   *
-   * @param reviewId - The ID of the review to react to
-   * @param userId - The ID of the user reacting
-   * @param reactionType - The type of reaction ('like' or 'dislike')
-   * @returns An observable of the updated review with reaction status
-   */
-  toggleReactionPATCH(
-    reviewId: string,
-    userId: string,
-    reactionType: 'like' | 'dislike'
-  ): Observable<any> {
-    return this.http
-      .patch<any>(
-        `${this.url}/reviews/toggle-reaction/${reviewId}`,
-        { userId, reactionType },
-        { withCredentials: true }
-      )
-      .pipe(
-        tap({
-          next: (response) => {
-            // console.log('ApiService | Successfully toggled like/dislike', response);
-          },
-          error: (error) => {
-            // console.error('ApiService | Error whilst toggling like/dislike', error.error);
-          },
-        })
-      );
-  }
-
-  /**
    * * GET Get Unit by Unitcode
    *
    * Retrieves a unit by its unit code.
@@ -158,28 +79,6 @@ export class ApiService {
         error: (error) => {
           // ? Debug log
           // console.log('ApiService | Error whilst fetching unit:', error.error);
-        },
-      })
-    );
-  }
-
-  /**
-   * * GET Get All Units
-   *
-   * Retrieves all units.
-   *
-   * @returns {Observable<Unit[]>} An observable containing an array of all units
-   */
-  getAllUnits(): Observable<Unit[]> {
-    return this.http.get<Unit[]>(`${this.url}/units`).pipe(
-      tap({
-        next: (response) => {
-          // ? Debug log
-          // console.log('ApiService | Successfully fetched all units:', response);
-        },
-        error: (error) => {
-          // ? Debug log
-          // console.log('ApiService | Error whilst fetching all units:', error.error);
         },
       })
     );
@@ -204,173 +103,6 @@ export class ApiService {
           // console.log('ApiService | Error whilst fetching popular units:', error.error);
         },
       })
-    );
-  }
-
-  /**
-   * * GET Get Units Filtered
-   *
-   * Retrieves units based on the provided filters.
-   *
-   * @param {number} offset The offset for pagination
-   * @param {number} limit The limit for pagination
-   * @param {string} [search=''] The search query for filtering units
-   * @param {string} [faculty] The faculty to filter by
-   * @returns {Observable<Unit[]>} An observable containing an array of filtered units
-   */
-  getUnitsFilteredGET(
-    offset: number,
-    limit: number,
-    search: string = '',
-    sort: string = 'Alphabetic',
-    showReviewed?: boolean,
-    showUnreviewed?: boolean,
-    hideNoOfferings?: boolean,
-    faculty?: string[],
-    semesters?: string[],
-    campuses?: string[]
-  ): Observable<Unit[]> {
-    let params = new HttpParams()
-      .set('offset', offset.toString())
-      .set('limit', limit.toString())
-      .set('search', search)
-      .set('sort', sort);
-
-    // Add boolean parameters only if they are defined
-    if (showReviewed !== undefined) {
-      params = params.set('showReviewed', showReviewed ? 'true' : 'false');
-    }
-    if (showUnreviewed !== undefined) {
-      params = params.set('showUnreviewed', showUnreviewed ? 'true' : 'false');
-    }
-    if (hideNoOfferings !== undefined) {
-      params = params.set(
-        'hideNoOfferings',
-        hideNoOfferings ? 'true' : 'false'
-      );
-    }
-    // Add array parameters only if they have values
-    if (faculty && faculty.length > 0) {
-      faculty.forEach((f) => {
-        params = params.append('faculty', f);
-      });
-    }
-
-    if (semesters && semesters.length > 0) {
-      semesters.forEach((s) => {
-        params = params.append('semesters', s);
-      });
-    }
-
-    if (campuses && campuses.length > 0) {
-      campuses.forEach((c) => {
-        params = params.append('campuses', c);
-      });
-    }
-
-    return this.http.get<Unit[]>(`${this.url}/units/filter`, { params }).pipe(
-      tap({
-        next: (response) => {
-          // ? Debug log
-          // console.log('ApiService | Successfully fetched filtered units:', response);
-        },
-        error: (error) => {
-          // ? Debug log
-          // console.log('ApiService | Error whilst fetching filtered units:', error.error);
-        },
-      })
-    );
-  }
-
-  /**
-   * * POST Create a Review for a Unit
-   *
-   * Creates a new review for a unit.
-   *
-   * @param {string} unitcode The unit code of the unit
-   * @param {Review} review The review object containing review details
-   * @returns {Observable<any>} An observable containing the response from the server
-   */
-  createReviewForUnitPOST(unitcode: string, review: Review): Observable<any> {
-    return this.http
-      .post(
-        `${this.url}/reviews/${unitcode}/create`,
-        {
-          review_title: review.title,
-          review_semester: review.semester,
-          review_grade: review.grade,
-          review_year: review.year,
-          review_overall_rating: review.overallRating,
-          review_relevancy_rating: review.relevancyRating,
-          review_faculty_rating: review.facultyRating,
-          review_content_rating: review.contentRating,
-          review_description: review.description,
-          review_author: review.author,
-        },
-        { withCredentials: true }
-      )
-      .pipe(
-        tap({
-          next: (response) => {
-            // ? Debug log
-            // console.log('AuthService | Successfully created review:', response);
-          },
-          error: (error) => {
-            // ? Debug log
-            // console.log('AuthService | Error whilst creating review:', error.error);
-          },
-        })
-      );
-  }
-
-  /**
-   * * DELETE Delete a Review by ID
-   *
-   * Deletes a review by its ID.
-   *
-   * @param {string} id The ID of the review
-   * @returns {Observable<any>} An observable containing the response from the server
-   */
-  deleteReviewByIdDELETE(id: string): Observable<any> {
-    return this.http
-      .delete(`${this.url}/reviews/delete/${id}`, { withCredentials: true })
-      .pipe(
-        tap({
-          next: (response) => {
-            // ? Debug log
-            // console.log('ApiService | Successfully deleted review:', response);
-          },
-          error: (error) => {
-            // ? Debug log
-            // console.log('ApiService | Error whilst deleting review:', error.error);
-          },
-        })
-      );
-  }
-
-  /**
-   * * PATCH Update a Review for a unit
-   *
-   * Updates a review by its ID.
-   *
-   * @param {Review} review The review object containing the updated review details
-   * @returns {Observable<any>} An observable containing the response from the server
-   */
-  editReviewPUT(review: Review): Observable<any> {
-    return this.http.put(
-      `${this.url}/reviews/update/${review._id}`,
-      {
-        title: review.title,
-        semester: review.semester,
-        grade: review.grade,
-        year: review.year,
-        overallRating: review.overallRating,
-        relevancyRating: review.relevancyRating,
-        facultyRating: review.facultyRating,
-        contentRating: review.contentRating,
-        description: review.description,
-      },
-      { withCredentials: true }
     );
   }
 

--- a/frontend/src/app/shared/services/auth.service.ts
+++ b/frontend/src/app/shared/services/auth.service.ts
@@ -41,33 +41,6 @@ export class AuthService {
   }
 
   /**
-   * * Register and/or login a Google user
-   *
-   * Register and/or logins a Google user using the Google ID token.
-   *
-   * @param {string} idToken The Google id token of the user.
-   * @returns {Observable<any>} an observable containing the response from the server.
-   */
-  googleAuthenticate(idToken: string): Observable<any> {
-    return this.http
-      .post(
-        `${this.url}/google/authenticate`,
-        { idToken },
-        { withCredentials: true }
-      )
-      .pipe(
-        tap((response: any) => {
-          // Update the current user with the response data
-          const user = new User(response.data);
-          this.currentUser.next(user);
-
-          // ? Debug log
-          // console.log('AuthService | Logged in as:', this.currentUser);
-        })
-      );
-  }
-
-  /**
    * * Refresh the access token using the refresh token
    *
    * Called automatically by the auth interceptor when the access token expires (after 15 minutes).
@@ -177,28 +150,6 @@ export class AuthService {
   }
 
   /**
-   * * Validate the user's session
-   *
-   * Validates the current user's session and updates the current user data.
-   *
-   * @returns {Observable<any>} an observable containing the response from the server.
-   */
-  validateSession(): Observable<any> {
-    return this.http
-      .get(`${this.url}/validate`, { withCredentials: true })
-      .pipe(
-        tap((response: any) => {
-          // Update the current user with the response data
-          const user = new User(response.data);
-          this.currentUser.next(user);
-
-          // ? Debug log
-          // console.log('AuthService | validated user as:', this.currentUser);
-        })
-      );
-  }
-
-  /**
    * * Verify and login the user
    *
    * Verifies the user's email using the provided token and logs them in.
@@ -247,37 +198,6 @@ export class AuthService {
 
             // ? Debug log
             // console.log('AuthService | Updated user details:', this.currentUser);
-          }
-        })
-      );
-  }
-
-  /**
-   * * Upload avatar
-   *
-   * Uploads a new avatar for the user.
-   *
-   * @param {string} file the avatar file to upload.
-   * @param {string} email The email of the user.
-   * @returns {Observable<{ profileImg: string }>} an observable containing updated profile image URL.
-   */
-  uploadAvatar(file: File, email: string): Observable<{ profileImg: string }> {
-    const formData = new FormData();
-    formData.append('avatar', file);
-    formData.append('email', email);
-
-    return this.http
-      .post<{
-        profileImg: string;
-      }>(`${this.url}/upload-avatar`, formData, { withCredentials: true })
-      .pipe(
-        tap((response: any) => {
-          // Update the current user's profile image
-          if (this.currentUser.value) {
-            this.currentUser.value.profileImg = response.profileImg;
-
-            // ? Debug log
-            // console.log('AuthService | Uploaded avatar:', this.currentUser);
           }
         })
       );

--- a/frontend/src/app/shared/services/setu.service.ts
+++ b/frontend/src/app/shared/services/setu.service.ts
@@ -23,46 +23,4 @@ export class SetuService {
       .get<SetuData[]>(`${this.apiUrl}/unit/${unitCode}`)
       .pipe(map((data) => data.map((item) => new Setu(item))));
   }
-
-  /**
-   * Get average SETU scores for a specific unit
-   * @param unitCode The unit code to get average scores for
-   * @returns Observable of average SETU scores
-   */
-  getAverageSetuScores(unitCode: string): Observable<any> {
-    return this.http.get<any>(`${this.apiUrl}/average/${unitCode}`);
-  }
-
-  /**
-   * Get SETU data for a specific season
-   * @param season The season to get SETU data for (e.g., "2019_S1")
-   * @returns Observable of SETU data array
-   */
-  getSetuBySeason(season: string): Observable<Setu[]> {
-    return this.http
-      .get<SetuData[]>(`${this.apiUrl}/season/${season}`)
-      .pipe(map((data) => data.map((item) => new Setu(item))));
-  }
-
-  /**
-   * Get all SETU data with pagination
-   * @param limit Number of items per page
-   * @param offset Starting offset
-   * @param sort Sort criteria
-   * @returns Observable of paginated SETU data
-   */
-  getAllSetu(
-    limit: number = 50,
-    offset: number = 0,
-    sort: string = 'unit_code'
-  ): Observable<any> {
-    return this.http
-      .get<any>(`${this.apiUrl}?limit=${limit}&offset=${offset}&sort=${sort}`)
-      .pipe(
-        map((response) => ({
-          ...response,
-          data: response.data.map((item: SetuData) => new Setu(item)),
-        }))
-      );
-  }
 }


### PR DESCRIPTION
Removes the frontend service methods left dead after #210 deleted their v1 backend endpoints.

All were self-only, no live callers. The live Google-auth and session-validation flows use the v2 api/user.service.ts, not these auth.service.ts copies.

## Removed

- api.service.ts: getAllReviewsGET, getUserReviewsGET, toggleReactionPATCH, getAllUnits, getUnitsFilteredGET, createReviewForUnitPOST, deleteReviewByIdDELETE, editReviewPUT. Also the now-unused HttpParams import.
- auth.service.ts: googleAuthenticate, validateSession, uploadAvatar.
- setu.service.ts: getAllSetu, getAverageSetuScores, getSetuBySeason.

## Out of scope

- auth.service.ts register, login, forgotPassword, resetPassword, verifyAndLogin still call endpoints this backend never had. That is a product decision (delete the UI or build the endpoints), tracked separately in #208.

## Verification

- npm ci in the worktree
- npx ng build: bundle generation complete, no type errors. Remaining warnings are pre-existing (bundle budgets, non-ESM modules, selector parsing).

Part of #208.
