### PR TITLE
Make the sidebar a persistent icon rail

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -13,6 +13,12 @@ body {
   flex-direction: column;
   min-height: 100%;
   background-color: $bg-dark-color;
+  padding-left: $sidebar-rail-width;
+
+  // The rail is hidden on mobile (the navbar hamburger opens it instead)
+  @media (max-width: 768px) {
+    padding-left: 0;
+  }
 }
 
 // Allow the content area to grow and fill space

--- a/frontend/src/app/shared/components/navbar/navbar.component.html
+++ b/frontend/src/app/shared/components/navbar/navbar.component.html
@@ -4,11 +4,11 @@
 
 <nav class="navbar navbar-expand-lg" [style.backgroundColor]="navbarColor">
   <div class="container-fluid d-flex justify-content-center position-relative">
-    <!-- Sidebar button -->
+    <!-- Sidebar button (mobile only; the rail has its own toggle on desktop) -->
     <div
       class="hamburger-menu position-absolute start-0 ml-2"
       type="button"
-      (click)="sidebarVisible = true"
+      (click)="sidebarExpanded.set(true)"
       [style.color]="hamburgColor"
     >
       <i
@@ -68,147 +68,71 @@
   </div>
 </nav>
 
-<!-- ! Sidebar-->
-<p-sidebar
-  #sidebarRef
-  [(visible)]="sidebarVisible"
-  [style]="{ 'background-color': '#1e1e1e' }"
->
-  <ng-template pTemplate="headless">
-    <div class="flex flex-column h-full">
-      <!-- Title Text-->
-      <div
-        class="flex align-items-center justify-content-between px-4 pt-3 flex-shrink-0"
+<!-- ! Sidebar rail -->
+@if (sidebarExpanded()) {
+  <div class="sidebar-backdrop" (click)="sidebarExpanded.set(false)"></div>
+}
+
+<aside class="sidebar-rail" [class.expanded]="sidebarExpanded()">
+  <!-- Toggle + Title -->
+  <a
+    pRipple
+    (click)="toggleSidebar()"
+    class="rail-item rail-toggle text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple prevent-select"
+    pTooltip="Sidebar (CTRL + S)"
+    tooltipPosition="right"
+    [tooltipDisabled]="sidebarExpanded()"
+  >
+    <span class="rail-icon">
+      <i
+        class="pi"
+        [class.pi-bars]="!sidebarExpanded()"
+        [class.pi-times]="sidebarExpanded()"
+      ></i>
+    </span>
+    <span class="rail-label sidebar-title font-semibold text-2xl">MonSTAR</span>
+  </a>
+
+  <!-- User Profile -->
+  <hr class="mx-2 border-top-1 border-none surface-border" />
+  <a
+    pRipple
+    (click)="sidebarExpanded.set(false); clickedProfileIcon()"
+    class="rail-item text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
+    [pTooltip]="state?.user?.username || 'Login (Guest)'"
+    tooltipPosition="right"
+    [tooltipDisabled]="sidebarExpanded()"
+  >
+    <span class="rail-icon">
+      <img
+        [src]="
+          state?.user?.profileImg ||
+          'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSWwfGUCDwrZZK12xVpCOqngxSpn0BDpq6ewQ&s'
+        "
+        alt="Profile Picture"
+        class="avatar"
+      />
+    </span>
+    <span class="rail-label font-bold">{{
+      state?.user?.username || 'Login (Guest)'
+    }}</span>
+  </a>
+  <hr class="mx-2 border-top-1 border-none surface-border" />
+
+  <!-- MAIN LINKS -->
+  <nav class="rail-links">
+    @for (link of railLinks; track link.route) {
+      <a
+        pRipple
+        (click)="navigateTo(link.route)"
+        class="rail-item text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
+        [pTooltip]="link.label"
+        tooltipPosition="right"
+        [tooltipDisabled]="sidebarExpanded()"
       >
-        <span class="inline-flex align-items-center gap-2">
-          <span class="font-semibold text-2xl sidebar-title prevent-select"
-            >MonSTAR</span
-          >
-        </span>
-
-        <!-- Close button -->
-        <i
-          class="pi pi-times"
-          (click)="sidebarVisible = false"
-          style="cursor: pointer; font-size: 1.5rem; color: white"
-          pTooltip="Close Sidebar"
-          tooltipPosition="bottom"
-        ></i>
-      </div>
-
-      <!-- User Profile -->
-      <div class="user">
-        <hr class="mx-3 border-top-1 border-none surface-border" />
-        <a
-          pRipple
-          (click)="closeSidebar($event); clickedProfileIcon()"
-          class="m-3 flex align-items-center cursor-pointer p-3 gap-2 border-round text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
-          style="text-decoration: none"
-        >
-          <!-- Avatar -->
-          <img
-            [src]="
-              state?.user?.profileImg ||
-              'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSWwfGUCDwrZZK12xVpCOqngxSpn0BDpq6ewQ&s'
-            "
-            alt="Profile Picture"
-            class="mr-1 avatar"
-          />
-
-          <!-- Username -->
-          <span class="font-bold mb-1 ml-2">{{
-            state?.user?.username || 'Login (Guest)'
-          }}</span>
-        </a>
-        <hr class="mx-3 border-top-1 border-none surface-border" />
-      </div>
-
-      <!-- MAIN LINKS -->
-      <div class="sidebar-links overflow-y-auto">
-        <ul class="list-none p-3 m-0">
-          <li>
-            <!-- <div pStyleClass="@next" class="p-3 flex align-items-center justify-content-between text-600 p-ripple prevent-select">
-                <span class="font-medium">NAVIGATION</span>
-              </div> -->
-            <ul class="list-none p-0 m-0 overflow-hidden">
-              <!-- Home Page -->
-              <li>
-                <a
-                  pRipple
-                  (click)="closeSidebar($event); navigateTo('/')"
-                  class="flex align-items-center cursor-pointer p-3 border-round text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
-                  style="text-decoration: none"
-                >
-                  <i class="pi pi-home mr-2"></i>
-                  <span class="font-medium">Home</span>
-                </a>
-              </li>
-              <!-- Unit List Page -->
-              <li>
-                <a
-                  pRipple
-                  (click)="closeSidebar($event); navigateTo('/list')"
-                  class="flex align-items-center cursor-pointer p-3 border-round text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
-                  style="text-decoration: none"
-                >
-                  <i class="pi pi-graduation-cap mr-2"></i>
-                  <span class="font-medium">Units</span>
-                </a>
-              </li>
-              <!-- Jobs Board Page -->
-              <li>
-                <a
-                  pRipple
-                  (click)="closeSidebar($event); navigateTo('/jobs')"
-                  class="flex align-items-center cursor-pointer p-3 border-round text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
-                  style="text-decoration: none"
-                >
-                  <i class="pi pi-briefcase mr-2"></i>
-                  <span class="font-medium">Student Roles</span>
-                </a>
-              </li>
-              <!-- Changelog Page -->
-              <li>
-                <a
-                  pRipple
-                  (click)="closeSidebar($event); navigateTo('/changelog')"
-                  class="flex align-items-center cursor-pointer p-3 border-round text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
-                  style="text-decoration: none"
-                >
-                  <i class="pi pi-sitemap mr-2"></i>
-                  <span class="font-medium">Changelog</span>
-                </a>
-              </li>
-              <!-- About Page -->
-              <li>
-                <a
-                  pRipple
-                  (click)="closeSidebar($event); navigateTo('/about')"
-                  class="flex align-items-center cursor-pointer p-3 border-round text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
-                  style="text-decoration: none"
-                >
-                  <i class="pi pi-info-circle mr-2"></i>
-                  <span class="font-medium">Contributions</span>
-                </a>
-              </li>
-              <!-- Terms and Conditions Page -->
-              <li>
-                <a
-                  pRipple
-                  (click)="
-                    closeSidebar($event); navigateTo('/terms-and-conditions')
-                  "
-                  class="flex align-items-center cursor-pointer p-3 border-round text-700 hover:surface-100 transition-duration-150 transition-colors p-ripple"
-                  style="text-decoration: none"
-                >
-                  <i class="pi pi-shield mr-2"></i>
-                  <span class="font-medium">Ts & Cs</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </ng-template>
-</p-sidebar>
+        <span class="rail-icon"><i [class]="link.icon"></i></span>
+        <span class="rail-label font-medium">{{ link.label }}</span>
+      </a>
+    }
+  </nav>
+</aside>

--- a/frontend/src/app/shared/components/navbar/navbar.component.scss
+++ b/frontend/src/app/shared/components/navbar/navbar.component.scss
@@ -27,9 +27,14 @@
   .hamburger-menu {
     border: none; // Removes the default border of the button
     padding: 0rem; // Minimal padding for the button
-    display: block; // Ensure it remains visible on all screen sizes
+    display: none; // Hidden on desktop; the sidebar rail has its own toggle
     transform: scale(1.5);
     user-select: none;
+
+    // Shown on mobile, where the collapsed rail is hidden
+    @media (max-width: 768px) {
+      display: block;
+    }
 
     i {
       transition: transform 0.3s ease-in-out;
@@ -104,23 +109,107 @@
   }
 }
 
-// * Sidebar text
-.sidebar-title {
-  color: white;
+// * Sidebar rail
+$rail-expanded-width: 260px;
+
+.sidebar-rail {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: $sidebar-rail-width;
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-dark-color;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  z-index: 1000;
   font-family: $poppins;
+  transition:
+    width 0.2s ease,
+    transform 0.2s ease;
+
+  &.expanded {
+    width: $rail-expanded-width;
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.5);
+
+    .rail-label {
+      opacity: 1;
+    }
+  }
+
+  // On mobile the collapsed rail hides completely; the navbar hamburger
+  // slides it in expanded
+  @media (max-width: 768px) {
+    transform: translateX(-100%);
+
+    &.expanded {
+      transform: translateX(0);
+    }
+  }
+
+  // A row in the rail: fixed-width icon column + label revealed on expand
+  .rail-item {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    height: 48px;
+    margin: 2px 6px;
+    border-radius: 8px;
+    cursor: pointer;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .rail-toggle {
+    height: 52px;
+    margin-top: 4px;
+
+    i {
+      font-size: 1.25rem;
+    }
+  }
+
+  .rail-icon {
+    flex: 0 0 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .rail-label {
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  .rail-links {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 0.25rem 0;
+  }
+
+  .sidebar-title {
+    color: white;
+  }
+
+  .avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
 }
 
-.sidebar-links {
-  font-family: $poppins;
-}
-
-// * Sidebar avatar
-.avatar {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  object-fit: cover;
-  position: relative;
+// Dims the page while the rail is expanded; click collapses it
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 999;
 }
 
 // * Prevents user selection

--- a/frontend/src/app/shared/components/navbar/navbar.component.ts
+++ b/frontend/src/app/shared/components/navbar/navbar.component.ts
@@ -1,11 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import {
-  Component,
-  HostListener,
-  inject,
-  OnInit,
-  ViewChild
-} from '@angular/core';
+import { Component, HostListener, inject, OnInit, signal } from '@angular/core';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
 import { UserService } from '@services/api/user.service';
 import { IUser } from 'app/shared/models/v2/user.schema';
@@ -15,7 +9,6 @@ import { BadgeModule } from 'primeng/badge';
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 import { RippleModule } from 'primeng/ripple';
-import { Sidebar, SidebarModule } from 'primeng/sidebar';
 import { StyleClassModule } from 'primeng/styleclass';
 import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
@@ -26,8 +19,14 @@ import { ViewportService, ViewportType } from '../../services/viewport.service';
 import { NotificationsPopupComponent } from '../notifications/notifications-popup/notifications-popup.component';
 
 export interface State {
-  isAuthenticated: boolean,
-  user: IUser | null,
+  isAuthenticated: boolean;
+  user: IUser | null;
+}
+
+interface RailLink {
+  label: string;
+  icon: string;
+  route: string;
 }
 
 @Component({
@@ -35,7 +34,6 @@ export interface State {
   standalone: true,
   imports: [
     RouterLink,
-    SidebarModule,
     ButtonModule,
     RippleModule,
     StyleClassModule,
@@ -52,8 +50,16 @@ export interface State {
   styleUrl: './navbar.component.scss',
 })
 export class NavbarComponent implements OnInit {
-  @ViewChild('sidebarRef') sidebarRef!: Sidebar;
-  sidebarVisible: boolean = false;
+  sidebarExpanded = signal(false);
+
+  readonly railLinks: RailLink[] = [
+    { label: 'Home', icon: 'pi pi-home', route: '/' },
+    { label: 'Units', icon: 'pi pi-graduation-cap', route: '/list' },
+    { label: 'Student Roles', icon: 'pi pi-briefcase', route: '/jobs' },
+    { label: 'Changelog', icon: 'pi pi-sitemap', route: '/changelog' },
+    { label: 'Contributions', icon: 'pi pi-info-circle', route: '/about' },
+    { label: 'Ts & Cs', icon: 'pi pi-shield', route: '/terms-and-conditions' },
+  ];
 
   username: string | undefined = '';
 
@@ -75,14 +81,14 @@ export class NavbarComponent implements OnInit {
       const state: State = {
         isAuthenticated: false,
         user: null,
-      }
+      };
       if (!user) return state;
-      
+
       state.isAuthenticated = user ? true : false;
       state.user = user;
       return state;
     })
-  )
+  );
 
   constructor() {
     this.router.events
@@ -114,30 +120,22 @@ export class NavbarComponent implements OnInit {
 
   clickedProfileIcon() {
     const user = this.userService.currentUserValue;
-    if (!user) { 
-      this.router.navigate(['/auth']); 
+    if (!user) {
+      this.router.navigate(['/auth']);
       return;
     }
     return this.router.navigate(['/user/' + user.username]);
   }
 
-  @HostListener('document:keydown', ['$event'])
+  // Toggles the sidebar rail on CTRL+S
+  @HostListener('document:keydown.control.s', ['$event'])
   handleKeyboardEvent(event: KeyboardEvent) {
-    // If the user presses 's' then we open the sidebar
-    if (event.ctrlKey && event.key === 's') {
-      event.preventDefault();
-
-      if (!this.sidebarVisible) {
-        this.sidebarVisible = true;
-      } else {
-        this.sidebarVisible = false;
-      }
-    }
+    event.preventDefault();
+    this.toggleSidebar();
   }
 
-  // Closes the sidebar
-  closeSidebar(e: any): void {
-    this.sidebarRef.close(e);
+  toggleSidebar(): void {
+    this.sidebarExpanded.update((expanded) => !expanded);
   }
 
   /**
@@ -161,9 +159,10 @@ export class NavbarComponent implements OnInit {
   }
 
   /**
-   * Navigates to a page (but scrolls to top)
+   * Navigates to a page from the rail (collapses it, scrolls to top)
    */
   navigateTo(route: string) {
+    this.sidebarExpanded.set(false);
     this.navigationService.navigateTo([route]);
   }
 }

--- a/frontend/src/app/styles/variables.scss
+++ b/frontend/src/app/styles/variables.scss
@@ -8,3 +8,5 @@ $fg-dark-color: #2c2c2c;
 
 $poppins: 'Poppins', sans-serif;
 $ryzes: 'Ryzes';
+
+$sidebar-rail-width: 60px;


### PR DESCRIPTION
Closes #209

## What

- Replaces the PrimeNG overlay sidebar with a rail that stays on screen.
- Collapsed, the rail is a 60px strip: toggle, avatar, then the six route icons with tooltips.
- The toggle or CTRL+S expands it to 260px, showing labels next to the icons. A backdrop dims the page; clicking it, a link, or the toggle collapses the rail.
- On viewports at or under 768px the collapsed rail sits off screen and the navbar hamburger opens it, so mobile keeps the old behaviour.

## How

- [frontend/src/app/shared/components/navbar/navbar.component.html](https://github.com/wiredmonash/monstar/blob/feat/sidebar-rail/frontend/src/app/shared/components/navbar/navbar.component.html) renders the rail as a plain aside; one @for over railLinks produces the six links.
- [frontend/src/app/shared/components/navbar/navbar.component.ts](https://github.com/wiredmonash/monstar/blob/feat/sidebar-rail/frontend/src/app/shared/components/navbar/navbar.component.ts) holds sidebarExpanded as a signal, defines railLinks (label, icon, route), binds CTRL+S with keydown.control.s and drops SidebarModule.
- [frontend/src/app/shared/components/navbar/navbar.component.scss](https://github.com/wiredmonash/monstar/blob/feat/sidebar-rail/frontend/src/app/shared/components/navbar/navbar.component.scss) nests the rail styles under .sidebar-rail, including the expanded state and the mobile media query.
- [frontend/src/app/app.component.scss](https://github.com/wiredmonash/monstar/blob/feat/sidebar-rail/frontend/src/app/app.component.scss) pads the layout by $sidebar-rail-width from [frontend/src/app/styles/variables.scss](https://github.com/wiredmonash/monstar/blob/feat/sidebar-rail/frontend/src/app/styles/variables.scss); mobile drops the padding.
