### PR TITLE
Remove dead review-report email endpoint and nodemailer dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,8 +24,7 @@
         "jsonwebtoken": "~9.0.3",
         "mongoose": "~8.21.0",
         "multer": "2.0.2",
-        "multer-storage-cloudinary": "4.0.0",
-        "nodemailer": "~7.0.12"
+        "multer-storage-cloudinary": "4.0.0"
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
@@ -37,7 +36,6 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^2.1.0",
         "@types/node": "^26.0.0",
-        "@types/nodemailer": "^8.0.1",
         "@types/supertest": "^7.2.0",
         "artillery": "2.0.27",
         "eslint": "9.39.2",
@@ -6905,16 +6903,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/nodemailer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
-      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -15750,15 +15738,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,8 +39,7 @@
     "jsonwebtoken": "~9.0.3",
     "mongoose": "~8.21.0",
     "multer": "2.0.2",
-    "multer-storage-cloudinary": "4.0.0",
-    "nodemailer": "~7.0.12"
+    "multer-storage-cloudinary": "4.0.0"
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",
@@ -52,7 +51,6 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^2.1.0",
     "@types/node": "^26.0.0",
-    "@types/nodemailer": "^8.0.1",
     "@types/supertest": "^7.2.0",
     "artillery": "2.0.27",
     "eslint": "9.39.2",

--- a/backend/src/docs/swagger.json
+++ b/backend/src/docs/swagger.json
@@ -477,16 +477,10 @@
             "schema": {
               "type": "object",
               "properties": {
-                "reportReason": {
+                "userId": {
                   "example": "any"
                 },
-                "reportDescription": {
-                  "example": "any"
-                },
-                "reporterName": {
-                  "example": "any"
-                },
-                "review": {
+                "reactionType": {
                   "example": "any"
                 }
               }
@@ -497,45 +491,8 @@
           "200": {
             "description": "OK"
           },
-          "201": {
-            "description": "Created"
-          }
-        }
-      }
-    },
-    "/api/v2/reviews/send-report": {
-      "post": {
-        "tags": [
-          "Reviews V2"
-        ],
-        "summary": "Send report email for a review",
-        "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "reportReason": {
-                  "example": "any"
-                },
-                "reportDescription": {
-                  "example": "any"
-                },
-                "reporterName": {
-                  "example": "any"
-                },
-                "review": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created"
+          "400": {
+            "description": "Bad Request"
           }
         }
       }

--- a/backend/src/domains/academics/reviews/review.controller.ts
+++ b/backend/src/domains/academics/reviews/review.controller.ts
@@ -1,5 +1,3 @@
-import nodemailer from 'nodemailer';
-
 import asyncHandler from '@shared/utilities/asyncHandler';
 import ReviewService from './review.service';
 
@@ -139,41 +137,6 @@ class ReviewController {
     );
 
     return res.status(200).json(result);
-  });
-
-  /**
-   * Send report email for a review
-   */
-  static sendReport = asyncHandler(async (req, res) => {
-    const { reportReason, reportDescription, reporterName, review } = req.body;
-
-    const transporter = nodemailer.createTransport({
-      service: 'Gmail',
-      auth: {
-        user: process.env.EMAIL_USERNAME,
-        pass: process.env.EMAIL_PASSWORD,
-      },
-    });
-
-    await transporter.sendMail({
-      from: process.env.EMAIL_USERNAME,
-      to: process.env.EMAIL_USERNAME,
-      subject: `Report on review written by user ${review.author.username}`,
-      html: `<p>
-Reporter: ${reporterName} <br>
-Reason: ${reportReason} <br>
-Description: ${reportDescription} <br>
-<br>
-Author ID: ${review.author._id} <br>
-Author Username: ${review.author.username} <br>
-<br>
-Review ID: ${review._id} <br>
-Review Title: ${review.title} <br>
-Review Description: ${review.description} <br>
-</p>`,
-    });
-
-    return res.status(201).json({ message: 'Report email sent' });
   });
 }
 

--- a/backend/src/domains/academics/reviews/reviews.v2.routes.ts
+++ b/backend/src/domains/academics/reviews/reviews.v2.routes.ts
@@ -66,12 +66,4 @@ router.patch(
   ReviewController.toggleReaction
 );
 
-router.post(
-  '/send-report',
-  userMiddleware,
-  // #swagger.tags = ['Reviews V2']
-  // #swagger.summary = 'Send report email for a review'
-  ReviewController.sendReport
-);
-
 export default router;

--- a/backend/src/shared/testing/integration.setup.ts
+++ b/backend/src/shared/testing/integration.setup.ts
@@ -46,13 +46,6 @@ vi.mock('@docs/swagger', () => ({
   setupSwagger: vi.fn().mockResolvedValue(undefined),
 }));
 
-/* ----- Stub nodemailer so report emails never hit a real SMTP server ----- */
-vi.mock('nodemailer', () => ({
-  default: {
-    createTransport: () => ({ sendMail: vi.fn().mockResolvedValue({}) }),
-  },
-}));
-
 /**
  * Converts values of data into mongoose types
  */

--- a/frontend/src/app/shared/components/review-card/review-card.component.html
+++ b/frontend/src/app/shared/components/review-card/review-card.component.html
@@ -42,7 +42,7 @@
     (mouseleave)="deleteButtonState = 'hidden'"
   >
     <div class="review-card position-relative">
-      <!-- Buttons for deletion and reporting (shown in top right of review card) -->
+      <!-- Button for deletion/modification (shown in top right of review card) -->
       @if (state && state.isAuthor) {
         <!--Review Modification Button -->
         <div
@@ -240,7 +240,7 @@
               <div
                 class="col-md-3 col-lg-3 d-flex flex-column justify-content-end actions"
               >
-                <!-- Report and dislike/like buttons -->
+                <!-- Dislike/like buttons -->
                 <div class="action-buttons-container">
                   <!-- Thumbs up/down -->
                   <div class="thumb-buttons">

--- a/frontend/src/app/shared/components/review-card/review-card.component.scss
+++ b/frontend/src/app/shared/components/review-card/review-card.component.scss
@@ -34,7 +34,7 @@
       font-weight: bold;
     }
 
-    // * Top right button for reporting/deleting review (hidden unless hovered)
+    // * Top right button for deleting/modifying review (hidden unless hovered)
     .top-right-button {
       position: absolute;
       top: 1rem;
@@ -216,16 +216,6 @@
                 color: white;
                 transform: scale(1.4);
               }
-            }
-          }
-
-          .report-button {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-
-            &:hover {
-              color: white;
             }
           }
         }


### PR DESCRIPTION
Closes #226

Removes the review-report email feature, which has been dead code since the frontend disabled it in b901982 ("frontend: disable handling of report-review").

## What

- Delete ReviewController.sendReport and the send-report route in [reviews.v2.routes.ts](https://github.com/wiredmonash/monstar/blob/remove-review-report-feature/backend/src/domains/academics/reviews/reviews.v2.routes.ts)
- Drop nodemailer and @types/nodemailer from [backend/package.json](https://github.com/wiredmonash/monstar/blob/remove-review-report-feature/backend/package.json)
- Remove the nodemailer stub from [integration.setup.ts](https://github.com/wiredmonash/monstar/blob/remove-review-report-feature/backend/src/shared/testing/integration.setup.ts)
- Regenerate swagger.json so the send-report path is gone
- Remove the orphaned report-button styles and stale comments in review-card

## Why

- Nothing calls POST /api/v2/reviews/send-report. No frontend request, no service method, no test.
- nodemailer carries a high-severity advisory. Removing the feature clears it outright instead of a risky nodemailer 7 to 9 major bump.

## Verified

- Backend: build green, 53/53 tests pass
- Booted backend on 8081: GET /api/v2/reviews/popular returns 200, POST /api/v2/reviews/send-report returns 404
- swagger.json regenerated, send-report path removed (+4/-47, scoped)
- Frontend: build green, review cards render clean

## Note

- EMAIL_USERNAME and EMAIL_PASSWORD env vars are now unused. Safe to drop from the deploy config separately.