### PR TITLE
Return a real 404 for disabled SETU routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,11 @@
       "dest": "/frontend/$1"
     },
     {
+      "src": "/setu(/.*)?",
+      "status": 404,
+      "dest": "/frontend/index.html"
+    },
+    {
       "src": "/(.*)",
       "dest": "/frontend/index.html"
     }


### PR DESCRIPTION
Closes #230

Disabled SETU routes returned HTTP 200 (soft 404), so Google kept the ~5,875 /setu/ URLs indexed even after #221 removed them from the sitemap. This makes them return a real 404.

## Change
- Add a Vercel route before the catch-all that serves index.html with a 404 status for /setu paths: [vercel.json](https://github.com/wiredmonash/monstar/blob/setu-hard-404/vercel.json#L27-L31).

## Behavior
- /setu, /setu/, and /setu/* return HTTP 404, still rendering the branded NotFound page.
- /setup, /setu-overview, /units, and every other route pass through unchanged.

## Verification
- vercel.json is valid JSON.
- The 404 rule precedes the catch-all.
- Regex matches only /setu and /setu/*, tested against /setup, /setu-overview, /units, /, and /api/v2/units, which all pass through.
- Live 404 status confirmed on the Vercel preview deployment (see below).

## Re-enable caveat
- Scoped to /setu because the whole prefix is dead while SETU is disabled. If SETU is re-enabled (the enableSetuCards flag), remove this route or it will 404 the real pages. Same coupling as the sitemap flag in #221.
