### PR TITLE
Fix cramped 404 page layout

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -11,7 +11,8 @@ body {
 .wrapper {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   background-color: $bg-dark-color;
   padding-left: $sidebar-rail-width;
 

--- a/frontend/src/app/routes/not-found/not-found.component.scss
+++ b/frontend/src/app/routes/not-found/not-found.component.scss
@@ -1,9 +1,16 @@
+:host {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
 .card-container {
+  flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding-top: 10rem;
+  padding: 2rem 1rem;
 
   .emoji {
     transform: scale(4);


### PR DESCRIPTION
Closes #229

The 404 page content sat at a fixed offset with the footer right below it, so the page looked short with dead space beneath the footer.

## Changes
- Center the skull and card in the available space using flex growth on the not-found host and card container, instead of a fixed padding-top.
- Fix .wrapper min-height so it reaches the viewport (100% never resolved because html/body height is not set globally after it was commented out). Uses 100dvh so the footer pins to the bottom on short pages.

## Verified
- Rendered the 404 route in a headless browser at desktop (1440x900) and mobile (390x844).
- Card is centered vertically between navbar and footer, footer sits at the viewport bottom.
- Measured element boxes: wrapper now fills 900px viewport (was 517px), content fills the gap, footer at the bottom.
- Checked list and jobs pages for regressions from the wrapper change: both render correctly, footers land at the bottom.