### PR TITLE
Remove GITHUB_TOKEN logic from contributors gateway

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -22,9 +22,6 @@ CLOUDINARY_URL='your-cloudinary-account-url'
 # This is for logging in with google
 GOOGLE_CLIENT_ID='671526426147-a16p1qi3iq3mtf672f7ka5hlpq8mvl3d.apps.googleusercontent.com'
 
-# This is for the contributors in about section fetched from GitHub
-GITHUB_TOKEN='your-access-token-for-github-contributions'
-
 # Google Gemini Generative AI
 GEMINI_API_KEY=''
 # Optional: Override the default Gemini model (e.g. gemini-2.0-flash)

--- a/backend/src/domains/platform/github/github.gateway.ts
+++ b/backend/src/domains/platform/github/github.gateway.ts
@@ -7,25 +7,11 @@ const REPO_OWNER = 'wiredmonash';
 const REPO_NAME = 'monstar';
 
 /**
- * Get GitHub token from environment variables
+ * Headers for GitHub API requests.
  *
- * TODO: Check if this is still required now that the repo is public.
- */
-const getGitHubToken = () => {
-  return process.env.GITHUB_TOKEN;
-};
-
-/**
- * Get authenticated headers for GitHub API requests
+ * The repo is public, so contributors are readable unauthenticated. No token.
  */
 const getAuthHeaders = () => {
-  const token = getGitHubToken();
-  if (token) {
-    return {
-      Authorization: `token ${token}`,
-      Accept: 'application/vnd.github.v3+json',
-    };
-  }
   return {
     Accept: 'application/vnd.github.v3+json',
   };
@@ -55,7 +41,7 @@ class GithubGateway {
   }
 
   /**
-   * Whether an error means the repository is private or the token is invalid
+   * Whether an error means the repository is private
    * (GitHub responds 401/403 in that case).
    */
   static isRepositoryAccessError(error: unknown): boolean {

--- a/backend/src/shared/testing/integration.setup.ts
+++ b/backend/src/shared/testing/integration.setup.ts
@@ -39,7 +39,6 @@ process.env.CLOUDINARY_API_SECRET = 'test';
 process.env.CLOUDINARY_URL = 'cloudinary://test:test@test';
 process.env.GEMINI_API_KEY = '';
 process.env.NOTION_PAGE_ID = '';
-process.env.GITHUB_TOKEN = '';
 
 /* ----- Stub Swagger so importing the app doesn't generate/serve docs ----- */
 vi.mock('@docs/swagger', () => ({


### PR DESCRIPTION
Closes #239

## What

Removes the GITHUB_TOKEN logic from the contributors gateway. The endpoint now makes a plain unauthenticated call to the GitHub API.

The repo is public, so contributors are readable without a token. This also resolves the TODO that was sitting on the old token helper.

## Changes

- [github.gateway.ts](https://github.com/wiredmonash/monstar/blob/remove-github-token-logic/backend/src/domains/platform/github/github.gateway.ts): delete getGitHubToken and the token branch in getAuthHeaders. Send only the Accept header. Trim the token mention from the isRepositoryAccessError comment.
- [integration.setup.ts](https://github.com/wiredmonash/monstar/blob/remove-github-token-logic/backend/src/shared/testing/integration.setup.ts): drop the now-dead GITHUB_TOKEN test stub.
- [.env.template](https://github.com/wiredmonash/monstar/blob/remove-github-token-logic/backend/.env.template): drop the GITHUB_TOKEN entry.

## Verified

- Typecheck passes (npm run typecheck).
- The two github endpoint integration tests pass.
- Booted the backend and hit /api/v1/github/contributors: HTTP 200, "Contributors fetched successfully" (live success path, not the fallback), 10 real contributors returned.

## Follow-up

- Remove the GITHUB_TOKEN env var from the Vercel dashboard after merge.
- The old PAT is still in local backend/.env files. Worth revoking it since it no longer serves a purpose.
