### PR TITLE
Set per-unit canonical URL on unit pages

### DIFF
--- a/frontend/src/app/routes/unit-overview/unit-overview.component.ts
+++ b/frontend/src/app/routes/unit-overview/unit-overview.component.ts
@@ -378,5 +378,17 @@ export class UnitOverviewComponent implements OnInit, AfterViewInit, OnDestroy {
         unitAverageRating
       ),
     });
+
+    // Canonical URL pointing at this unit (overrides the homepage default in
+    // index.html) so Google indexes each unit page as its own page.
+    const existingCanonical = document.querySelector('link[rel="canonical"]');
+    if (existingCanonical) {
+      existingCanonical.remove();
+    }
+
+    const canonicalLink = document.createElement('link');
+    canonicalLink.setAttribute('rel', 'canonical');
+    canonicalLink.setAttribute('href', pageUrl);
+    document.head.appendChild(canonicalLink);
   }
 }


### PR DESCRIPTION
Closes #235

## Problem

- Every unit page served the homepage canonical from [frontend/src/index.html#L52](https://github.com/wiredmonash/monstar/blob/fix-unit-canonical-url/frontend/src/index.html#L52).
- [unit-overview.component.ts](https://github.com/wiredmonash/monstar/blob/fix-unit-canonical-url/frontend/src/app/routes/unit-overview/unit-overview.component.ts) set the title, description, and Open Graph tags per unit but never touched the canonical.
- Google read /unit/:code as a duplicate of the homepage and could drop unit pages from the index.

## Fix

- Override the canonical link at the end of updateMetaTags to point at the current unit, reusing the pageUrl already computed for og:url.
- Follows the same remove-then-append pattern [unit-list.component.ts#L437-L452](https://github.com/wiredmonash/monstar/blob/fix-unit-canonical-url/frontend/src/app/routes/unit-list/unit-list.component.ts#L437-L452) uses.

## Verification

- Ran the frontend against the dev backend and loaded pages in a headless browser.
- /unit/fit1045 canonical is now https://monstar.wired.org.au/unit/fit1045
- /unit/fit2004 canonical is now https://monstar.wired.org.au/unit/fit2004
- /list and / canonicals unchanged.
