### PR TITLE
Add issue forms and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report something that is broken or behaving unexpectedly
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Fill in the sections below so we can reproduce it.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you see?
+      placeholder: The unit page shows a blank rating.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the steps that trigger the bug.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the app is affected? Select all that apply.
+      multiple: true
+      options:
+        - frontend
+        - backend
+        - infra
+        - database
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Screenshots or logs
+      description: Paste any console output, screenshots, or error messages.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/wiredmonash/monstar/blob/main/CONTRIBUTING.md
+    about: Read this before opening an issue or pull request.

--- a/.github/ISSUE_TEMPLATE/feature_or_task.yml
+++ b/.github/ISSUE_TEMPLATE/feature_or_task.yml
@@ -1,0 +1,44 @@
+name: Feature or task
+description: Propose a new feature, improvement, or task
+title: "[Task]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the change and why it matters.
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: The change in a sentence or two.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: The problem it solves or the value it adds.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the app does this touch? Select all that apply.
+      multiple: true
+      options:
+        - frontend
+        - backend
+        - infra
+        - database
+        - seo
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes or constraints
+      description: Anything else worth knowing.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- One or two sentences: what changed and why -->
+
+## Changes
+
+-
+
+## Verification
+
+<!-- How you confirmed it works: tests run, commands, screenshots -->
+-
+
+## Linked issue
+
+Closes #
+
+## Checklist
+
+- [ ] Labelled: one type (bug, enhancement, refactor, security, perf, documentation) plus area (frontend, backend, infra, database, seo)
+- [ ] Priority label set if this PR tracks an issue
+- [ ] PR body reads cleanly: active voice, no em dashes


### PR DESCRIPTION
## Summary

- Add structured GitHub templates so contributors provide reproduction details, expected behaviour, scope, and verification.

## Changes

- Contributors can choose bug or feature/task forms with type labels and required prompts.
- Repository settings disable blank issues and link the contributing guide.
- The pull request template asks authors for a summary, changes, verification, a linked issue, and a checklist.

## Verification

- I ran `git diff --check origin/main...HEAD`.

Closes #242