### PR TITLE
Match Google users by googleID in v2 auth lookup

### DIFF
--- a/backend/src/domains/identity/users/user.repository.ts
+++ b/backend/src/domains/identity/users/user.repository.ts
@@ -20,7 +20,7 @@ class UserRepository {
    */
   static async findByEmailOrGoogleId(email: string, googleId: string) {
     return await User.findOne({
-      $or: [{ email: email }, { googleId: googleId }],
+      $or: [{ email: email }, { googleID: googleId }],
     });
   }
 

--- a/backend/src/domains/identity/users/user.service.test.ts
+++ b/backend/src/domains/identity/users/user.service.test.ts
@@ -116,6 +116,29 @@ describe(UserService.name, () => {
       expect(updatedUser.refreshToken).not.toBe('old-token');
     });
 
+    it('should match an existing Google user by Google ID when the email differs', async () => {
+      // arrange: user's stored email differs from the email Google returns,
+      // but the Google sub (googleID) is the same
+      const storedEmail = 'jdoe4242@student.monash.edu';
+      const newEmail = 'jane.doe@monash.edu';
+      const googleID = 'google-shared-sub';
+      const existingUser = await User.create({
+        email: storedEmail,
+        username: 'jdoe4242',
+        googleID,
+        isGoogleUser: true,
+        verified: true,
+      });
+      setupGoogleMock(newEmail, 'Jane Doe', googleID);
+
+      // act
+      const result = await UserService.googleAuthenticate(fakeIdTokenString);
+
+      // assert: matched the existing user rather than creating a new one
+      expect(result.user._id.toString()).toEqual(existingUser._id.toString());
+      expect(await User.countDocuments({ googleID })).toBe(1);
+    });
+
     it('should throw Error409Conflict if account exists but is not a Google account', async () => {
       const email = 'jdoe6767@student.monash.edu';
       await User.create({


### PR DESCRIPTION
## What

`findByEmailOrGoogleId` filtered the `$or` on `{ googleId: ... }`, but the schema field is `googleID` (`user.model.ts`). The Google-ID arm never matched, so `googleAuthenticate` effectively looked users up by email only. Point the query at the real `googleID` field.

## Why it matters

Masked in the common case by the email arm. But if a user's Google email ever differs from the stored one, v2 auth would treat them as a new user instead of matching by their Google sub.

## Test

Added a characterization test for a Google user whose stored email differs from the email Google returns but whose `googleID` matches. It fails against the old field name (looks the user up, finds nothing, creates a duplicate) and passes with the fix.

Full backend suite: 54 passed. Typecheck clean.

## Note

Existing docs may still carry the old email if this path ever mismatched before; a backfill check is out of scope here.

Closes #202