### PR TITLE
Record retroactive ADRs for the project's architectural history

### DIFF
--- a/.contextive/definitions.yml
+++ b/.contextive/definitions.yml
@@ -59,6 +59,32 @@ contexts:
         definition: The official Monash registry of all units, courses, and rules for a given year. The "Source of Truth".
 
   - name: Teaching Evaluation
-    terms: 
+    terms:
       - name: setu
-        definition: Student evaluation of teaching and units.
+        definition: Student Evaluation of Teaching and Units, Monash's official survey producing quantitative scores per unit offering.
+        examples:
+          - SETU data is confidential under the LTQP and cannot be republished by MonSTAR without Monash's permission (see ADR-0013).
+      - name: ltqp
+        definition: Learning and Teaching Quality Procedure, the Monash policy governing who may receive and distribute SETU data.
+        aliases:
+          - learning and teaching quality procedure
+        examples:
+          - Under LTQP clause 2.5, SETU responses are confidential and WIRED is not an authorised recipient.
+
+  - name: MonSTAR Platform
+    domainVisionStatement: Helping Monash students choose units through peer reviews and summaries.
+    terms:
+      - name: monstar
+        definition: 'The WIRED Monash unit-review platform: "Mon" for Monash, "STAR" for star-based reviewing; a brand name rather than an acronym.'
+        examples:
+          - MonSTAR is growing beyond reviews, so the name is treated as a general brand.
+      - name: review
+        definition: A student's subjective, star-rated evaluation of a unit posted on MonSTAR.
+        examples:
+          - A review belongs to exactly one unit and one verified student.
+      - name: ai overview
+        definition: A generated summary of a unit's reviews and metrics shown on the unit page.
+        aliases:
+          - overview
+        examples:
+          - The AI overview condenses a unit's reviews so a student gets a quick take without reading all of them.

--- a/.docs/adr/0001-angular-express-mongodb-stack.md
+++ b/.docs/adr/0001-angular-express-mongodb-stack.md
@@ -1,0 +1,41 @@
+---
+title: Use Angular, Express, and MongoDB as the core stack
+status: accepted
+date: 2024-09-04
+tags: [frontend, backend, infra]
+---
+
+# Use Angular, Express, and MongoDB as the core stack
+
+## Context and Problem Statement
+
+MonSTAR (repo slug `wired-unit-review` at the time) needed a web stack for a unit-review platform run by a rotating team of student contributors at WIRED Monash. The stack had to be easy for new members to pick up and cheap enough for a student-club budget.
+
+## Decision Drivers
+
+- Team familiarity: the founding contributors knew Angular, Express, and MongoDB, or were learning them.
+- Maintainability with a rotating contributor base: strong conventions matter more than flexibility.
+- Zero or near-zero hosting cost.
+
+## Considered Options
+
+- Angular + Express + MongoDB (MEAN)
+- React frontend
+- SQL database (PostgreSQL/MySQL)
+
+## Decision Outcome
+
+Chosen: **Angular + Express + MongoDB**.
+
+**Angular over React:** Angular enforces strong separation between components and features and ships with router, HTTP client, forms, and DI included. React projects accumulate clutter and ad-hoc structure; Angular's opinionated layout keeps the codebase navigable as contributors rotate through the club.
+
+**MongoDB over SQL:** one economic reason and one modeling reason.
+
+- MongoDB Atlas's free 500 MB tier made it the zero-cost choice.
+- Units and reviews are document-shaped (nested reviews, flexible fields), and the app had low relational complexity: few entities, few joins. The team judged SQL's multi-table machinery unwarranted at this scale.
+
+### Consequences
+
+- Good: new contributors find a conventional Angular/Express layout with little architectural bikeshedding.
+- Good: the database costs nothing to host.
+- Risk: if the domain grows more relational (many cross-entity features), the team may revisit a relational database. The team acknowledged this at decision time.

--- a/.docs/adr/0002-primeng-ui-library.md
+++ b/.docs/adr/0002-primeng-ui-library.md
@@ -1,0 +1,21 @@
+---
+title: Adopt PrimeNG as the UI component library, phasing out Bootstrap
+status: accepted
+date: 2024-10-14
+tags: [frontend]
+---
+
+# Adopt PrimeNG as the UI component library, phasing out Bootstrap
+
+## Context
+
+The frontend started on Bootstrap, which covers layout and basic styling but lacks rich interactive components. The write-review dialog and homepage accordion needed more than Bootstrap offered.
+
+## Decision
+
+Adopt PrimeNG as the component library and phase Bootstrap out over time. The team layered PrimeNG on top of Bootstrap via CSS layers (`public/styles/layer.css`), moved style references from `angular.json` into `styles.scss`, and added `provideAnimations()` to enable PrimeNG's animated components, so both libraries could coexist during the transition.
+
+## Consequences
+
+- PrimeNG gave the team dialogs, accordions, and sidebars without custom builds.
+- The team has not finished the Bootstrap phase-out: as of 2026, `bootstrap`, `bootstrap-icons`, and `primeng` all remain in `package.json`. The dual dependency is drift from this decision's intent. Finishing the migration, or reversing this ADR, remains open.

--- a/.docs/adr/0003-wiredmonash-org-ownership.md
+++ b/.docs/adr/0003-wiredmonash-org-ownership.md
@@ -1,0 +1,23 @@
+---
+title: Move the repository to the wiredmonash organization with a Jira-backed team workflow
+status: accepted
+date: 2024-12-16
+tags: [process]
+---
+
+# Move the repository to the wiredmonash organization with a Jira-backed team workflow
+
+## Context
+
+MonSTAR was a WIRED Monash project from the beginning: team member Phuong Do proposed the review-platform idea, and Jenul Ferdinand led a team of student developers while a student himself. The repo, though, sat under the project lead's personal GitHub account with the slug `wired-unit-review`.
+
+The name was MonSTAR from day one: "Mon" for Monash, "STAR" for star-based reviewing. It is a brand rather than an acronym, and as the platform grows beyond unit reviews the team treats it as a general name.
+
+## Decision
+
+Move the repository to the `wiredmonash` GitHub organization under the `monstar` slug, and coordinate team work through Jira with `MONSTAR-N` ticket IDs in branches and commits.
+
+## Consequences
+
+- Ownership matches reality: the project belongs to the club and survives contributor turnover.
+- Branch and commit names (`MONSTAR-N`) tie code changes to tickets during the Jira era. Later eras moved to descriptive branch names and conventional commits.

--- a/.docs/adr/0004-linode-vps-hosting.md
+++ b/.docs/adr/0004-linode-vps-hosting.md
@@ -1,0 +1,25 @@
+---
+title: Host production on the WIRED Linode VPS at monstar.wired.org.au
+status: superseded
+superseded-by: 0010-migrate-to-vercel.md
+date: 2024-12-01
+tags: [infra]
+---
+
+# Host production on the WIRED Linode VPS at monstar.wired.org.au
+
+## Context
+
+Faye ran WIRED Monash's club website (`wired.org.au`) on a Linode VPS. MonSTAR needed a production home and had no budget for dedicated infrastructure.
+
+## Decision
+
+Deploy MonSTAR on the same Linode server, next to the club website, at the subdomain `monstar.wired.org.au`. The app ran as a plain Node/Express server from `/var/www/monstar`. Faye set up the original deployment; after that the project lead deployed by hand until September 2025, when a GitHub Action took over the job (ADR-0009).
+
+A December 2024 `vercel.json` experiment (routing the whole app through `@vercel/node`) never served production traffic.
+
+## Consequences
+
+- Zero additional hosting cost and a working deployment with no new infrastructure decisions.
+- Each deploy depended on one person's server access and a root-SSH pull pipeline, a fragile arrangement.
+- The Vercel migration (ADR-0010) superseded this in November 2025.

--- a/.docs/adr/0005-google-only-auth.md
+++ b/.docs/adr/0005-google-only-auth.md
@@ -1,0 +1,28 @@
+---
+title: Use Google OAuth as the only sign-in method
+status: accepted
+date: 2025-02-25
+tags: [backend, frontend, security]
+---
+
+# Use Google OAuth as the only sign-in method
+
+## Context
+
+MonSTAR launched with hand-rolled email/password registration and login next to Google sign-in. Both paths required Monash-email student verification, so verification did not distinguish them. The concern was the manual auth implementation itself: password handling that student developers wrote in-house may not have been secure.
+
+## Decision
+
+Remove email/password auth and keep Google OAuth as the sole sign-in method.
+
+Google because:
+
+- Delegating auth to a third party removes the risk surface of self-managed passwords: hashing, resets, breaches.
+- Google accounts are ubiquitous among students.
+- Monash student Okta accounts work with Google sign-in the same way, so the target audience loses nothing.
+
+## Consequences
+
+- No password storage or reset flows to maintain or get wrong.
+- Sign-in depends on Google availability and OAuth client configuration.
+- Later hardening (JWT refresh tokens, ADR-0011) builds on this single-provider model.

--- a/.docs/adr/0006-setu-data-integration.md
+++ b/.docs/adr/0006-setu-data-integration.md
@@ -1,0 +1,30 @@
+---
+title: Integrate scraped SETU survey data into unit pages
+status: superseded
+superseded-by: 0013-remove-setu-data.md
+date: 2025-05-06
+tags: [backend, frontend, product, seo]
+---
+
+# Integrate scraped SETU survey data into unit pages
+
+## Context
+
+MonSTAR's value depends on unit pages having content, but a young review platform has a cold-start problem: most units have few or no student reviews. Monash publishes SETU (Student Evaluation of Teaching and Units) survey results, official quantitative scores per unit offering.
+
+## Decision
+
+Scrape SETU results and integrate them into the platform:
+
+- A scraper (later the `data/` folder) ingested SETU results; bulk-create endpoints loaded them.
+- Unit overview pages showed a SETU card next to student reviews; each unit got a dedicated SETU page, plus a SETU main page.
+- SETU pages got SEO treatment: meta tags and generated sitemap entries, making thousands of unit-offering pages indexable.
+
+## Rationale
+
+Official aggregate scores complement subjective student reviews, so a unit page stays useful with zero user reviews. The indexable SETU pages were an SEO play to pull search traffic to the platform.
+
+## Consequences
+
+- Unit pages had content from day one of the feature; search traffic grew.
+- WIRED republished the data without authorization from Monash. The university lodged a formal complaint in December 2025; ADR-0013 reverses this decision.

--- a/.docs/adr/0007-ai-overviews-gemini.md
+++ b/.docs/adr/0007-ai-overviews-gemini.md
@@ -1,0 +1,23 @@
+---
+title: Generate AI overviews for units using Gemini 2.5 Pro
+status: accepted
+date: 2025-09-22
+tags: [backend, frontend, product, ai]
+---
+
+# Generate AI overviews for units using Gemini 2.5 Pro
+
+## Context
+
+Unit pages accumulate reviews and quantitative metrics; a student deciding on a unit wants a quick take without reading it all.
+
+## Decision
+
+Add per-unit AI overviews: the backend feeds a unit's reviews and metrics (as an XML-structured prompt) to Gemini 2.5 Pro and stores the summary; the frontend shows it on the unit overview page with a model badge and a loading skeleton. The team added an `llms.txt` for AI crawlers in the same push.
+
+The team picked Gemini for its free tier; on a student-club budget, cost mattered more than marginal quality.
+
+## Consequences
+
+- Unit pages get a readable summary that scales with review volume at no API cost.
+- Output quality and availability track Google's free-tier terms; swapping models means re-tuning the prompt, kept in XML for structure.

--- a/.docs/adr/0008-swagger-api-docs.md
+++ b/.docs/adr/0008-swagger-api-docs.md
@@ -1,0 +1,21 @@
+---
+title: Document the API with Swagger, replacing Bruno collections
+status: accepted
+date: 2025-09-26
+tags: [backend, process]
+---
+
+# Document the API with Swagger, replacing Bruno collections
+
+## Context
+
+New student contributors needed a browsable, current API reference. Contributors maintained the Bruno request collections by hand, and the collections drifted from the real API.
+
+## Decision
+
+Adopt Swagger (OpenAPI), served by the backend, as the canonical API documentation. The team deleted the Bruno files in December 2025 ("since we have swagger now") and adopted Prettier in the same contributor-experience push.
+
+## Consequences
+
+- Contributors explore and try endpoints from the Swagger UI instead of reading route code.
+- Someone must keep the spec honest: dev boots can clobber `swagger.json` with stale definitions, and swagger generation needed fixes when the team restructured routes in June and July 2026.

--- a/.docs/adr/0009-automated-linode-deploys.md
+++ b/.docs/adr/0009-automated-linode-deploys.md
@@ -1,0 +1,22 @@
+---
+title: Automate Linode deploys with a GitHub Actions workflow
+status: superseded
+superseded-by: 0010-migrate-to-vercel.md
+date: 2025-09-24
+tags: [infra, ci]
+---
+
+# Automate Linode deploys with a GitHub Actions workflow
+
+## Context
+
+The project lead deployed to the Linode VPS (ADR-0004) by hand: SSH in, git pull, reinstall. Each release waited on his availability.
+
+## Decision
+
+Add a GitHub Actions workflow (`deploy.yml`) that, on push to `main`, SSHes into the server, git-pulls, and reinstalls dependencies. Follow-up commits pinned the action SHA, serialized concurrent runs, and skipped deploys for docs-only changes.
+
+## Consequences
+
+- Merging to `main` deploys; nobody waits on the one person with server access.
+- The pipeline still ran as root over SSH with a password secret. The team accepted this as a stopgap, and the Vercel migration (ADR-0010) retired it two months later.

--- a/.docs/adr/0010-migrate-to-vercel.md
+++ b/.docs/adr/0010-migrate-to-vercel.md
@@ -1,0 +1,25 @@
+---
+title: Migrate hosting from the Linode VPS to Vercel serverless
+status: accepted
+date: 2025-11-26
+tags: [infra]
+supersedes: [0004-linode-vps-hosting.md, 0009-automated-linode-deploys.md]
+---
+
+# Migrate hosting from the Linode VPS to Vercel serverless
+
+## Context
+
+MonSTAR ran on the shared WIRED Linode VPS (ADR-0004) with a root-SSH pull deploy pipeline (ADR-0009). The club paid for the server, and the team owned its upkeep: OS, nginx, process management, each outage.
+
+## Decision
+
+Move the whole app to Vercel: the Angular frontend as static assets on the CDN, the Express backend as a serverless function (`@vercel/node`), with `vercel.json` routing between them. Deploys become git-push previews and automatic production deploys; the team deleted the old CI workflow.
+
+Cost and operational burden drove the move: Vercel's free tier with zero server maintenance beat paying for and babysitting a VPS.
+
+## Consequences
+
+- No servers to maintain; preview deployments per branch; the team added Vercel Analytics.
+- The team engineered around serverless constraints: Mongo connections optimized for function reuse (ready-state checks), SPA routing expressed in `vercel.json` (several iterations to mimic `express.static`), and a query-parameter serialization fix.
+- Two later decisions follow from this one: the team added Redis caching (ADR-0012) to absorb per-invocation Mongo latency, and TypeScript path aliases forced the backend to ship as compiled JS (ADR-0014).

--- a/.docs/adr/0011-jwt-refresh-tokens.md
+++ b/.docs/adr/0011-jwt-refresh-tokens.md
@@ -1,0 +1,21 @@
+---
+title: Add JWT refresh tokens to keep users signed in
+status: accepted
+date: 2025-12-14
+tags: [backend, security]
+---
+
+# Add JWT refresh tokens to keep users signed in
+
+## Context
+
+After Google sign-in (ADR-0005), short-lived JWT access tokens carried sessions. When a token expired, the app logged the user out without warning and forced a fresh sign-in, a recurring complaint.
+
+## Decision
+
+Introduce refresh tokens (PR #131): the access token stays short-lived, and a refresh token obtains new access tokens behind the scenes, extending session life without lengthening the access-token TTL.
+
+## Consequences
+
+- Users stay signed in across visits; no more surprise logouts.
+- The team chose this over the lazy fix, long-lived access tokens, to keep the blast radius of a leaked token small.

--- a/.docs/adr/0012-upstash-redis-caching.md
+++ b/.docs/adr/0012-upstash-redis-caching.md
@@ -1,0 +1,25 @@
+---
+title: Cache hot endpoints in Upstash Redis
+status: accepted
+date: 2025-12-21
+tags: [backend, infra, performance]
+---
+
+# Cache hot endpoints in Upstash Redis
+
+## Context
+
+On Vercel (ADR-0010), each function invocation pays MongoDB connection and query cost. Hot read endpoints (unit lists, unit overviews) were slow because of this per-invocation latency.
+
+## Decision
+
+Add a Redis cache layer using Upstash (PR #132):
+
+- Upstash serves Redis over HTTP, the flavor that fits Vercel functions, and has a free tier.
+- A cache provider wraps hot reads; an admin router exposes a cache-invalidation helper endpoint; invalidation uses pattern matching.
+- Tests mock Redis via `ioredis-mock`, and the team added artillery to load-test the gains.
+
+## Consequences
+
+- Hot endpoints skip Mongo on cache hits.
+- Cache invalidation is now a correctness concern: writes must invalidate matching keys, and the team later added manual invalidation hooks to the frontend (jobs board).

--- a/.docs/adr/0013-remove-setu-data.md
+++ b/.docs/adr/0013-remove-setu-data.md
@@ -1,0 +1,34 @@
+---
+title: Remove all SETU data following Monash takedown request
+status: accepted
+date: 2025-12-23
+tags: [backend, frontend, product, legal]
+supersedes: 0006-setu-data-integration.md
+---
+
+# Remove all SETU data following Monash takedown request
+
+## Context
+
+On 16 December 2025, Monash Student Conduct, on advice from the university's Office of General Counsel, requested that WIRED remove all SETU data from its sites within 5 working days (by 23 December 2025, 11 PM). The advice held that:
+
+- SETU survey responses are confidential under the Learning and Teaching Quality Procedure (LTQP) clause 2.5, which limits distribution to defined university audiences; nothing in the LTQP authorizes public publication.
+- Publishing the data may breach clause 2.3 of the university's Media and Social Media Policy (confidential information in media).
+- Restricting the WIRED site to staff and students would not cure the breach, because the LTQP does not list WIRED as an authorized recipient of SETU data at all.
+- Copyright in the compilation and presentation of the data (as opposed to raw numbers) remained an open question.
+
+Monash could refer non-compliance to Student Conduct as general misconduct.
+
+## Decision
+
+Comply and remove SETU from the platform:
+
+- The team removed SETU data and UI by the 23 December 2025 deadline (`fix/remove-setu`, PR #133, merged 23 Dec 2025).
+- July 2026 follow-ups hardened SETU routes to hard 404s (rather than soft redirects) and removed SETU sitemap entries so search engines drop the pages.
+- PR #254 deleted the remaining public SETU API endpoints (July 2026).
+
+## Consequences
+
+- The platform loses its official-data content layer and the SEO surface built on it (ADR-0006 superseded); student reviews and AI overviews carry unit pages instead.
+- Monash accepted the removal and took no further conduct action.
+- WIRED plans to ask Monash for permission to reinstate SETU data through an authorized arrangement. If Monash agrees, a new ADR should record the terms.

--- a/.docs/adr/0014-backend-typescript-conversion.md
+++ b/.docs/adr/0014-backend-typescript-conversion.md
@@ -1,0 +1,28 @@
+---
+title: Convert the backend to TypeScript
+status: accepted
+date: 2026-07-05
+tags: [backend]
+---
+
+# Convert the backend to TypeScript
+
+## Context
+
+After about two years of plain JavaScript, the untyped Express/Mongoose codebase kept biting rotating student contributors: silent field-name mismatches (the `googleId`/`googleID` class of bug), untyped request handlers, and Mongoose documents with no compile-time shape.
+
+## Decision
+
+Convert the whole backend to TypeScript (PR #192, shipped 5 July 2026):
+
+- Type helpers derive Mongoose model types from the schemas (unit, review, user, notification, org logo, setu), so no hand-written interface can drift from its schema.
+- Typed Express helpers wrap request handlers; the team converted the providers (mongodb, cloudinary, cache) first.
+- AI-assisted refactoring made the conversion practical in 2026; by hand it would have been prohibitive for a student team.
+
+**Deployment consequence:** `@vercel/node` cannot resolve TS path aliases, so the Vercel backend function serves compiled JS (`index.js` pointing into `dist/`) instead of building from TS source.
+
+## Consequences
+
+- Field-name and shape mismatches are compile errors instead of production bugs.
+- Contributors get editor-level API discovery on models and handlers.
+- The build step (and the compiled-JS Vercel entrypoint) is now part of the deploy contract.

--- a/.docs/adr/0015-ddd-bounded-contexts.md
+++ b/.docs/adr/0015-ddd-bounded-contexts.md
@@ -1,0 +1,26 @@
+---
+title: Restructure the backend into DDD bounded contexts
+status: accepted
+date: 2026-07-05
+tags: [backend, architecture]
+---
+
+# Restructure the backend into DDD bounded contexts
+
+## Context
+
+The backend was organized layer-by-type (`routes/`, `controllers/`, `models/`), so each feature change touched folders across the tree and new contributors had no obvious home for new code. The project lead had also been studying domain-driven design (the Contextive glossary in `.contextive/`, domain-modeling practice) and chose to bring that discipline to the project.
+
+## Decision
+
+Restructure `backend/src/` into bounded contexts (units, reviews, users, notifications, and so on), each exposing a public API through its `index.ts`:
+
+- Cross-context imports go through the target context's `index.ts`; no reaching into internals.
+- PR #201 folded the legacy v1 API routes into their owning domains as `*.v1.*` files and deleted the separate `deprecated/` tree.
+- The glossary in `.contextive/definitions.yml` records the ubiquitous language the structure follows.
+
+## Consequences
+
+- A feature change stays inside one context, and contributors navigate by domain noun.
+- The `*.v1.*` naming contains and marks v1 endpoints for removal as v2 cutovers proceed (units read cutover and dead v1 endpoint drops, July 2026).
+- Reviewers must hold the import discipline at `index.ts` boundaries. Known gotcha: some entrypoints must import model files for their side effects.

--- a/.docs/adr/README.md
+++ b/.docs/adr/README.md
@@ -1,0 +1,23 @@
+# Architecture Decision Records
+
+MonSTAR's architectural decisions, reconstructed from git history (September 2024 onward) and maintainer interviews in July 2026, extended as new decisions land. One file per decision, numbered by decision date. Frontmatter carries `status`, `date`, and `tags` (`frontend`, `backend`, `infra`, `product`, `security`, `process`, ...).
+
+| ADR | Date | Decision | Status |
+|-----|------|----------|--------|
+| [0001](0001-angular-express-mongodb-stack.md) | 2024-09 | Angular + Express + MongoDB stack | accepted |
+| [0002](0002-primeng-ui-library.md) | 2024-10 | PrimeNG UI library, Bootstrap to be phased out | accepted (phase-out unfinished) |
+| [0003](0003-wiredmonash-org-ownership.md) | 2024-12 | Repo owned by wiredmonash org, Jira workflow | accepted |
+| [0004](0004-linode-vps-hosting.md) | 2024-12 | Host on WIRED Linode VPS (monstar.wired.org.au) | superseded by 0010 |
+| [0005](0005-google-only-auth.md) | 2025-02 | Google OAuth as the only sign-in | accepted |
+| [0006](0006-setu-data-integration.md) | 2025-05 | Integrate scraped SETU data | superseded by 0013 |
+| [0007](0007-ai-overviews-gemini.md) | 2025-09 | AI overviews via Gemini 2.5 Pro | accepted |
+| [0008](0008-swagger-api-docs.md) | 2025-09 | Swagger API docs (replacing Bruno) | accepted |
+| [0009](0009-automated-linode-deploys.md) | 2025-09 | Automated Linode deploys via GitHub Actions | superseded by 0010 |
+| [0010](0010-migrate-to-vercel.md) | 2025-11 | Migrate hosting to Vercel serverless | accepted |
+| [0011](0011-jwt-refresh-tokens.md) | 2025-12 | JWT refresh tokens | accepted |
+| [0012](0012-upstash-redis-caching.md) | 2025-12 | Upstash Redis caching layer | accepted |
+| [0013](0013-remove-setu-data.md) | 2025-12 | Remove SETU data (Monash takedown) | accepted |
+| [0014](0014-backend-typescript-conversion.md) | 2026-07 | Backend TypeScript conversion | accepted |
+| [0015](0015-ddd-bounded-contexts.md) | 2026-07 | DDD bounded-context restructure | accepted |
+
+Adding a new ADR: copy the frontmatter of any file here, take the next number, and when a decision reverses an old one set `supersedes`/`superseded-by` on both files.


### PR DESCRIPTION
## What

- Adds [.docs/adr/](https://github.com/wiredmonash/monstar/blob/adr-record/.docs/adr/README.md) with 15 retroactive architecture decision records covering September 2024 to July 2026: one file per decision with status, date, and tags in frontmatter, plus an index.
- Extends [.contextive/definitions.yml](https://github.com/wiredmonash/monstar/blob/adr-record/.contextive/definitions.yml) with a MonSTAR Platform context (monstar, review, ai overview) and sharper Teaching Evaluation terms (SETU confidentiality, LTQP).

## Why

- Commit messages record what changed and drop the reasoning; only maintainers remember why the big calls happened (Linode to Vercel, SETU removal, Google-only auth).
- With ADRs in the repo, contributors read the rationale instead of re-mining 1,200+ commits or interviewing the project lead.

## Notes

- Reconstructed from git history plus a maintainer interview on 13 July 2026.
- Reversed decisions keep their records, marked superseded and cross-linked: SETU integration, Linode hosting, Linode deploy automation.
- One commit per ADR file, so each decision's record can be discussed or dropped in review on its own.