### PR TITLE
Centralize requisite retrieval and unit map data

### DIFF
--- a/frontend/src/app/routes/unit-map/unit-map.component.html
+++ b/frontend/src/app/routes/unit-map/unit-map.component.html
@@ -111,7 +111,7 @@
               class="unit-info-value"
               [style]="{ color: 'rgba(34, 197, 94, 0.75)' }"
             >
-              {{ prerequisiteUnitCodes ? prerequisiteUnitCodes : 'None' }}
+              {{ prerequisiteUnitCodes.length ? prerequisiteUnitCodes : 'None' }}
             </dd>
           </div>
           <!-- Prerequisite Number Required -->

--- a/frontend/src/app/routes/unit-map/unit-map.component.ts
+++ b/frontend/src/app/routes/unit-map/unit-map.component.ts
@@ -7,7 +7,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { Router } from '@angular/router';
-import { Edge, NgxGraphModule, NgxGraphZoomOptions } from '@swimlane/ngx-graph';
+import { NgxGraphModule, NgxGraphZoomOptions } from '@swimlane/ngx-graph';
 import * as shape from 'd3-shape';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -16,33 +16,12 @@ import { OrganizationChartModule } from 'primeng/organizationchart';
 import { ToolbarModule } from 'primeng/toolbar';
 import { TooltipModule } from 'primeng/tooltip';
 import { Subject } from 'rxjs';
-import { IUnitDeeplyPopulated } from '../../shared/models/v2/unit.schema';
+import {
+  UnitMapEdge,
+  UnitMapNode,
+} from '../../shared/models/v2/unit-map.model';
+import { IUnit } from '../../shared/models/v2/unit.schema';
 import { GetUnitService } from '../../shared/services/api/get-unit.service';
-
-/**
- * * Unit Node Interface
- *
- * An interface for the nodes in the unit graph
- */
-interface UnitNode {
-  id: string;
-  label: string;
-  data: {
-    type: 'prerequisite' | 'current' | 'parent';
-    name: string;
-  };
-}
-
-/**
- * * Unit Edge Interface
- *
- * An interface for the edges in the unit graph
- */
-interface UnitEdge extends Edge {
-  data?: {
-    type: 'prerequisite' | 'parent';
-  };
-}
 
 @Component({
   selector: 'app-unit-map',
@@ -63,8 +42,8 @@ interface UnitEdge extends Edge {
 export class UnitMapComponent implements OnInit, OnDestroy {
   @ViewChild('graphContainer') graphContainer!: ElementRef;
 
-  nodes: UnitNode[] = [];
-  edges: UnitEdge[] = [];
+  nodes: UnitMapNode[] = [];
+  edges: UnitMapEdge[] = [];
   layout = 'dagre';
   curve = shape.curveBasis;
 
@@ -73,10 +52,10 @@ export class UnitMapComponent implements OnInit, OnDestroy {
 
   isLoading: boolean = false;
 
-  unit: IUnitDeeplyPopulated | null = null;
+  unit: IUnit | null = null;
   prerequisiteNumReq: number = 0;
-  prerequisiteUnitCodes: string[] | null = null;
-  parentUnitCodes: string[] | null = null;
+  prerequisiteUnitCodes: string[] = [];
+  parentUnitCodes: string[] = [];
 
   /**
    * === Constructor ===
@@ -109,126 +88,24 @@ export class UnitMapComponent implements OnInit, OnDestroy {
   /**
    * * Fetch and Build Unit Graph
    *
-   * Fetches the current unit and its prerequisites and parent units, then build
-   * the graph.
-   *
-   * The graph is built by adding the current unit as the root node, prereqs as
-   * 'prerequisite' nodes, and parent units as 'parent' nodes.
-   *
-   * The edges are then added between the current unit and its prerequisites,
-   * and the current unit and its parent units.
+   * Reads the map-ready data from the unit module and applies it to the graph.
+   * The module owns fetching the unit and its parents and assembling the nodes,
+   * edges, and sidebar fields; this component only renders and centers them.
    */
   fetchAndBuildUnitGraph() {
     // Get the current unit's unitcode from the url
     const unitCode = this.router.url.split('/')[2];
 
-    // Fetch the current unit
-    this.getUnitService.getByUnitcode(unitCode, false, false).subscribe({
-      next: (unit) => {
-        // ? Debug log: Current unit
-        // console.log('Current unit:', unit);
+    this.getUnitService.getUnitMap(unitCode).subscribe({
+      next: (unitMap) => {
+        this.unit = unitMap.unit;
+        this.nodes = unitMap.nodes;
+        this.edges = unitMap.edges;
+        this.prerequisiteUnitCodes = unitMap.prerequisiteUnitCodes;
+        this.prerequisiteNumReq = unitMap.prerequisiteNumReq;
+        this.parentUnitCodes = unitMap.parentUnitCodes;
 
-        // Save the unit
-        this.unit = unit;
-
-        // Add current unit node from router param
-        const currentNode: UnitNode = {
-          id: unit.unitCode,
-          label: unit.unitCode.toUpperCase(),
-          data: {
-            type: 'current',
-            name: unit.name,
-          },
-        };
-        // ? Debug log: Current node
-        // console.log('Current node:', currentNode);
-
-        // Initalise arrays for prerequisites
-        let prereqNodes: UnitNode[] = [];
-        let prereqEdges: UnitEdge[] = [];
-
-        // Only process prerequisites if they exist
-        if (
-          unit.requisites?.prerequisites &&
-          unit.requisites.prerequisites.length > 0
-        ) {
-          // Add prerequisite nodes
-          prereqNodes = unit.requisites.prerequisites
-            .flatMap((group) => group.units)
-            .map((code) => ({
-              id: code,
-              label: code.toUpperCase(),
-              data: { type: 'prerequisite', name: code },
-            }));
-
-          // Save the prerequisite unit codes
-          this.prerequisiteUnitCodes = prereqNodes.map(
-            (node) => ' ' + node.label
-          );
-          // Save the prerequisite number required
-          this.prerequisiteNumReq =
-            unit.requisites.prerequisites[0].NumReq ?? 0;
-
-          // Add prerequisite edges
-          prereqEdges = prereqNodes.map((node) => ({
-            id: `${node.id}-${currentNode.id}`,
-            source: node.id,
-            target: currentNode.id,
-            data: { type: 'prerequisite' },
-          }));
-        }
-
-        // Set initial nodes and edges
-        this.nodes = [currentNode, ...prereqNodes];
-        this.edges = prereqEdges;
-
-        // Fetch the units that are required by the current unit
-        this.getUnitService.getUnitsRequiringUnit(unit.unitCode).subscribe({
-          next: (parentUnits) => {
-            // ? Debug log: Fetched parent units
-            // console.log('Parent units:', parentUnits);
-
-            // Add parent nodes
-            const parentNodes: UnitNode[] = parentUnits.map((parent) => ({
-              id: parent.unitCode,
-              label: parent.unitCode.toUpperCase(),
-              data: {
-                type: 'parent',
-                name: parent.name,
-              },
-            }));
-
-            // Save the parent unit codes
-            this.parentUnitCodes = parentNodes.map((node) => ' ' + node.label);
-
-            // ? Debug log: Parent nodes
-            // console.log('Parent nodes:', parentNodes);
-
-            // Add edges from current node to parent nodes
-            const parentEdges: UnitEdge[] = parentNodes.map((node) => ({
-              id: `${currentNode.id}-${node.id}`,
-              source: currentNode.id,
-              target: node.id,
-              data: { type: 'parent' },
-            }));
-
-            // ? Debug log: Parent edges
-            // console.log('Parent edges:', parentEdges);
-
-            // Add parent nodes and edges to the graph
-            this.nodes = [...this.nodes, ...parentNodes];
-            this.edges = [...this.edges, ...parentEdges];
-
-            // ? Debug log: Final graph state
-            // console.log('Final graph state:', {
-            //   nodes: this.nodes,
-            //   edges: this.edges
-            // });
-
-            // Center the graph
-            this.centerGraph();
-          },
-        });
+        this.centerGraph();
       },
     });
 

--- a/frontend/src/app/shared/components/unit-review-header/unit-review-header.component.ts
+++ b/frontend/src/app/shared/components/unit-review-header/unit-review-header.component.ts
@@ -154,7 +154,7 @@ export class UnitReviewHeaderComponent implements OnInit, OnDestroy, OnChanges {
 
     // Check if the unit has prerequisites or parent units
     if (this.unit) {
-      this.isUnitMapButtonEnabled = this.unitHasRequisites();
+      this.evaluateMapEligibility();
     }
   }
 
@@ -174,7 +174,7 @@ export class UnitReviewHeaderComponent implements OnInit, OnDestroy, OnChanges {
         changes['unit'].currentValue.unitCode !==
           changes['unit'].previousValue.unitCode)
     ) {
-      this.isUnitMapButtonEnabled = this.unitHasRequisites();
+      this.evaluateMapEligibility();
     }
   }
 
@@ -185,42 +185,29 @@ export class UnitReviewHeaderComponent implements OnInit, OnDestroy, OnChanges {
   /* ------------------------------- Validation ------------------------------- */
 
   /**
-   * * Check if unit has prerequisites and/or parent units
+   * * Evaluate whether the unit qualifies for a map
    *
-   * This checks if the unit has prerequisites or parent units by checking the unit object.
-   * - If the unit object doesn't have prerequisites, the unit map button is disabled.
-   * - If the unit object doesn't have parent units, the unit map button is disabled.
-   *
-   * @returns {boolean} Returns true if the unit has prerequisites or parent units, false otherwise.
+   * Asks the unit module whether the unit has prerequisites or is required by
+   * other units, and enables or disables the unit map button accordingly.
    */
-  unitHasRequisites(): boolean {
-    if (!this.unit) return false;
-
-    if (this.unit.requisites?.prerequisites?.length > 0) {
-      console.info(`UnitReviewHeader | Unit has requisites.`);
-      return true;
+  evaluateMapEligibility(): void {
+    if (!this.unit) {
+      this.isUnitMapButtonEnabled = false;
+      return;
     }
 
-    this.getUnitService.getUnitsRequiringUnit(this.unit.unitCode).subscribe({
-      next: (units) => {
-        if (units.length > 0) {
-          console.info('UnitReviewHeader | Unit has parent units.');
-          this.isUnitMapButtonEnabled = true;
-        } else {
-          console.warn('UnitReviewHeader | Unit has no parent units.');
-          this.isUnitMapButtonEnabled = false;
-        }
+    this.getUnitService.hasMapData(this.unit).subscribe({
+      next: (eligible) => {
+        this.isUnitMapButtonEnabled = eligible;
       },
       error: (error) => {
         console.error(
-          'UnitReviewHeader | Error whilst fetching parent units:',
+          'UnitReviewHeader | Error whilst checking map eligibility:',
           error.error
         );
         this.isUnitMapButtonEnabled = false;
       },
     });
-
-    return false;
   }
 
   /* ----------------------------- UI manipulation ---------------------------- */

--- a/frontend/src/app/shared/models/v2/unit-map.model.ts
+++ b/frontend/src/app/shared/models/v2/unit-map.model.ts
@@ -1,0 +1,43 @@
+import { IUnit } from './unit.schema';
+
+export type UnitMapNodeType = 'prerequisite' | 'current' | 'parent';
+export type UnitMapEdgeType = 'prerequisite' | 'parent';
+
+/**
+ * A node in the unit graph: the current unit, one of its prerequisites, or a
+ * parent unit that lists the current unit as a prerequisite.
+ */
+export interface UnitMapNode {
+  id: string;
+  label: string;
+  data: {
+    type: UnitMapNodeType;
+    name: string;
+  };
+}
+
+/**
+ * An edge in the unit graph, linking a prerequisite to the current unit or the
+ * current unit to a parent.
+ */
+export interface UnitMapEdge {
+  id: string;
+  source: string;
+  target: string;
+  data: {
+    type: UnitMapEdgeType;
+  };
+}
+
+/**
+ * Map-ready data assembled from a unit and the units that require it. Holds the
+ * graph nodes and edges plus the display fields the map sidebar renders.
+ */
+export interface UnitMap {
+  unit: IUnit;
+  nodes: UnitMapNode[];
+  edges: UnitMapEdge[];
+  prerequisiteUnitCodes: string[];
+  prerequisiteNumReq: number;
+  parentUnitCodes: string[];
+}

--- a/frontend/src/app/shared/services/api/get-unit.service.spec.ts
+++ b/frontend/src/app/shared/services/api/get-unit.service.spec.ts
@@ -8,8 +8,25 @@ import {
   IUnit,
   IUnitDeeplyPopulated,
 } from 'app/shared/models/v2/unit.schema';
+import { UnitMap } from 'app/shared/models/v2/unit-map.model';
 import { environment } from '../../../../environments/environment';
 import { GetUnitService } from './get-unit.service';
+
+/** Builds a minimal unit with the requisite fields the map logic reads. */
+function makeUnit(overrides: Partial<IUnit>): IUnit {
+  return {
+    unitCode: 'fit2004',
+    name: 'Algorithms and data structures',
+    requisites: {
+      permission: false,
+      prohibitions: [],
+      corequisites: [],
+      prerequisites: [],
+      cpRequired: 0,
+    },
+    ...overrides,
+  } as unknown as IUnit;
+}
 
 describe('GetUnitService', () => {
   let service: GetUnitService;
@@ -69,5 +86,128 @@ describe('GetUnitService', () => {
     req.flush(units);
 
     expect(result).toEqual(units);
+  });
+
+  describe('getUnitMap', () => {
+    // Reads a unit then its required-by units, and returns the assembled map.
+    function buildMap(unit: IUnit, parents: Partial<IUnit>[]): UnitMap {
+      let result: UnitMap | undefined;
+      service.getUnitMap('fit2004').subscribe((res) => (result = res));
+
+      httpMock.expectOne((r) => r.url === `${apiV2}/units/fit2004`).flush(unit);
+      httpMock.expectOne(`${apiV2}/units/fit2004/required-by`).flush(parents);
+
+      return result!;
+    }
+
+    it('builds only the current node for a unit with no requisites and no parents', () => {
+      const result = buildMap(makeUnit({ requisites: null as never }), []);
+
+      expect(result.nodes.map((n) => n.data.type)).toEqual(['current']);
+      expect(result.edges).toEqual([]);
+      expect(result.prerequisiteUnitCodes).toEqual([]);
+      expect(result.prerequisiteNumReq).toBe(0);
+      expect(result.parentUnitCodes).toEqual([]);
+    });
+
+    it('adds prerequisite nodes and edges from prerequisite groups', () => {
+      const unit = makeUnit({
+        requisites: {
+          permission: false,
+          prohibitions: [],
+          corequisites: [],
+          prerequisites: [{ NumReq: 1, units: ['FIT1045', 'FIT1053'] }],
+          cpRequired: 0,
+        },
+      });
+
+      const result = buildMap(unit, []);
+
+      expect(
+        result.nodes
+          .filter((n) => n.data.type === 'prerequisite')
+          .map((n) => n.label)
+      ).toEqual(['FIT1045', 'FIT1053']);
+      expect(result.edges.map((e) => e.data.type)).toEqual([
+        'prerequisite',
+        'prerequisite',
+      ]);
+      expect(result.prerequisiteUnitCodes).toEqual([' FIT1045', ' FIT1053']);
+      expect(result.prerequisiteNumReq).toBe(1);
+    });
+
+    it('leaves corequisites and prohibitions out of the graph', () => {
+      const unit = makeUnit({
+        requisites: {
+          permission: false,
+          prohibitions: ['FIT1040'],
+          corequisites: [{ NumReq: 1, units: ['FIT2085'] }],
+          prerequisites: [],
+          cpRequired: 0,
+        },
+      });
+
+      const result = buildMap(unit, []);
+
+      expect(result.nodes.map((n) => n.data.type)).toEqual(['current']);
+      expect(result.edges).toEqual([]);
+      expect(result.prerequisiteUnitCodes).toEqual([]);
+    });
+
+    it('adds parent nodes and edges from required-by units', () => {
+      const result = buildMap(makeUnit({ requisites: null as never }), [
+        { unitCode: 'fit3155', name: 'Advanced algorithms' },
+        { unitCode: 'fit2085', name: 'Systems' },
+      ]);
+
+      expect(
+        result.nodes.filter((n) => n.data.type === 'parent').map((n) => n.label)
+      ).toEqual(['FIT3155', 'FIT2085']);
+      expect(result.edges.map((e) => e.data.type)).toEqual(['parent', 'parent']);
+      expect(result.parentUnitCodes).toEqual([' FIT3155', ' FIT2085']);
+    });
+  });
+
+  describe('hasMapData', () => {
+    it('is eligible without a request when the unit has prerequisites', () => {
+      const unit = makeUnit({
+        unitCode: 'fit2004',
+        requisites: {
+          permission: false,
+          prohibitions: [],
+          corequisites: [],
+          prerequisites: [{ NumReq: 1, units: ['FIT1045'] }],
+          cpRequired: 0,
+        },
+      });
+      let eligible: boolean | undefined;
+
+      service.hasMapData(unit).subscribe((res) => (eligible = res));
+
+      httpMock.expectNone(`${apiV2}/units/fit2004/required-by`);
+      expect(eligible).toBe(true);
+    });
+
+    it('is eligible when required-by units exist', () => {
+      const unit = makeUnit({ unitCode: 'fit1045', requisites: null as never });
+      let eligible: boolean | undefined;
+
+      service.hasMapData(unit).subscribe((res) => (eligible = res));
+
+      httpMock
+        .expectOne(`${apiV2}/units/fit1045/required-by`)
+        .flush([{ unitCode: 'fit2004' }]);
+      expect(eligible).toBe(true);
+    });
+
+    it('is not eligible with no prerequisites and no required-by units', () => {
+      const unit = makeUnit({ unitCode: 'fit9999', requisites: null as never });
+      let eligible: boolean | undefined;
+
+      service.hasMapData(unit).subscribe((res) => (eligible = res));
+
+      httpMock.expectOne(`${apiV2}/units/fit9999/required-by`).flush([]);
+      expect(eligible).toBe(false);
+    });
   });
 });

--- a/frontend/src/app/shared/services/api/get-unit.service.ts
+++ b/frontend/src/app/shared/services/api/get-unit.service.ts
@@ -1,11 +1,16 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { Observable, tap } from 'rxjs';
+import { map, Observable, of, switchMap, tap } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 import {
   FilterData,
   FilteredUnitsResponse,
 } from '../../models/v2/unit.model';
+import {
+  UnitMap,
+  UnitMapEdge,
+  UnitMapNode,
+} from '../../models/v2/unit-map.model';
 import { IUnit, IUnitDeeplyPopulated } from 'app/shared/models/v2/unit.schema';
 
 @Injectable({
@@ -47,6 +52,81 @@ export class GetUnitService {
     return this.http.get<IUnit[]>(
       `${this.urlV2}/units/${unitCode}/required-by`
     );
+  }
+
+  /**
+   * Reads a unit and the units that require it, then assembles the graph nodes,
+   * edges, and sidebar fields the unit map renders.
+   */
+  getUnitMap(unitCode: string): Observable<UnitMap> {
+    return this.getByUnitcode(unitCode, false, false).pipe(
+      switchMap((unit) =>
+        this.getUnitsRequiringUnit(unit.unitCode).pipe(
+          map((parents) => this.assembleUnitMap(unit, parents))
+        )
+      )
+    );
+  }
+
+  /**
+   * Whether a unit qualifies for a map: it has prerequisites, or other units
+   * require it. Only fetches required-by units when there are no prerequisites.
+   */
+  hasMapData(unit: IUnit): Observable<boolean> {
+    if (this.flattenPrerequisiteCodes(unit).length > 0) return of(true);
+
+    return this.getUnitsRequiringUnit(unit.unitCode).pipe(
+      map((parents) => parents.length > 0)
+    );
+  }
+
+  private flattenPrerequisiteCodes(unit: IUnit): string[] {
+    return (unit.requisites?.prerequisites ?? []).flatMap(
+      (group) => group.units
+    );
+  }
+
+  private assembleUnitMap(unit: IUnit, parents: IUnit[]): UnitMap {
+    const currentNode: UnitMapNode = {
+      id: unit.unitCode,
+      label: unit.unitCode.toUpperCase(),
+      data: { type: 'current', name: unit.name },
+    };
+
+    const prereqNodes: UnitMapNode[] = this.flattenPrerequisiteCodes(unit).map(
+      (code) => ({
+        id: code,
+        label: code.toUpperCase(),
+        data: { type: 'prerequisite', name: code },
+      })
+    );
+    const prereqEdges: UnitMapEdge[] = prereqNodes.map((node) => ({
+      id: `${node.id}-${currentNode.id}`,
+      source: node.id,
+      target: currentNode.id,
+      data: { type: 'prerequisite' },
+    }));
+
+    const parentNodes: UnitMapNode[] = parents.map((parent) => ({
+      id: parent.unitCode,
+      label: parent.unitCode.toUpperCase(),
+      data: { type: 'parent', name: parent.name },
+    }));
+    const parentEdges: UnitMapEdge[] = parentNodes.map((node) => ({
+      id: `${currentNode.id}-${node.id}`,
+      source: currentNode.id,
+      target: node.id,
+      data: { type: 'parent' },
+    }));
+
+    return {
+      unit,
+      nodes: [currentNode, ...prereqNodes, ...parentNodes],
+      edges: [...prereqEdges, ...parentEdges],
+      prerequisiteUnitCodes: prereqNodes.map((node) => ' ' + node.label),
+      prerequisiteNumReq: unit.requisites?.prerequisites?.[0]?.NumReq ?? 0,
+      parentUnitCodes: parentNodes.map((node) => ' ' + node.label),
+    };
   }
 
   getUnitsFiltered({


### PR DESCRIPTION
## What

- Move required-by fetching, map-ready data assembly, and map eligibility into the frontend unit module.
- Unit Map and Unit Review Header now read requisite knowledge from the module instead of fetching and interpreting it themselves.

## Changes

- Add getUnitMap and hasMapData to get-unit.service.ts. getUnitMap reads a unit and its required-by units, then assembles the graph nodes, edges, and sidebar fields. hasMapData decides map eligibility and only fetches required-by units when the unit has no prerequisites.
- Add unit-map.model.ts with the node, edge, and map types. The types stay independent of ngx-graph.
- Unit Map consumes getUnitMap and keeps graph rendering, zoom, layout, and navigation. This drops roughly 150 lines of in-component fetching and assembly.
- Unit Review Header resolves the map button through hasMapData instead of fetching required-by units itself.
- Switch the prerequisites sidebar to a length check so an empty list still shows None.
- Add unit module tests for each requisite shape (no requisites, prerequisite groups, corequisites, prohibitions, required-by units) and the three eligibility branches.

## Backend

- Earlier work already removed the v1 required-by route and its characterization tests. This PR changes nothing on the backend.

## Verification

- ng build passes.
- ng test passes, 10 of 10 in headless Chrome.
- Ran the app against a preview: the FIT2004 map rendered the current unit, its prerequisites, and its parent units with the correct sidebar. The overview map button stayed enabled through hasMapData with no page errors.

Closes #260.
