### PR TITLE
Save reviews with no grade as null instead of a fake P

### DIFF
--- a/backend/src/domains/academics/reviews/review.model.ts
+++ b/backend/src/domains/academics/reviews/review.model.ts
@@ -5,7 +5,7 @@ const reviewSchema = new Schema(
     title: { type: String, required: true },
     semester: { type: String, required: true },
     year: { type: Number, required: true },
-    grade: { type: String, required: true },
+    grade: { type: String, enum: ['HD', 'D', 'C', 'P', 'N', null], default: null },
 
     overallRating: { type: Number, required: true, min: 0, max: 5 },
     relevancyRating: { type: Number, required: true, min: 0, max: 5 },

--- a/backend/src/domains/academics/reviews/review.service.test.ts
+++ b/backend/src/domains/academics/reviews/review.service.test.ts
@@ -88,6 +88,23 @@ describe(ReviewService.name, () => {
         unitBeforeReview.avgRelevancyRating
       );
     });
+
+    it('should store grade as null when none is provided', async () => {
+      const newReview = await ReviewService.createReview('fit5145', {
+        title: 'Testing title',
+        semester: 'Semester 2',
+        year: 2025,
+        overallRating: 5,
+        relevancyRating: 5,
+        contentRating: 5,
+        facultyRating: 5,
+        description: 'The quick brown fox jumps over the lazy dog',
+        author: '678e359d39d199c3f6b3b44f' as unknown as Types.ObjectId,
+      });
+
+      const stored = (await Review.findById(newReview._id))!;
+      expect(stored.grade).toBeNull();
+    });
   });
 
   /* -------------------------------- Reactions ------------------------------- */

--- a/frontend/src/app/shared/models/review.model.ts
+++ b/frontend/src/app/shared/models/review.model.ts
@@ -7,7 +7,7 @@ export interface ReviewData {
   _id?: Types.ObjectId;
   title?: string;
   semester?: string;
-  grade?: string;
+  grade?: string | null;
   year?: number;
   overallRating?: number;
   relevancyRating?: number;
@@ -26,7 +26,7 @@ export class Review {
   _id!: Types.ObjectId;
   title!: string;
   semester!: string;
-  grade!: string;
+  grade!: string | null;
   year!: number;
   overallRating!: number;
   relevancyRating!: number;
@@ -46,7 +46,7 @@ export class Review {
       this._id = new Types.ObjectId();
       this.title = '';
       this.semester = 'First semester';
-      this.grade = 'P';
+      this.grade = null;
       this.year = new Date().getFullYear();
       this.overallRating = 0;
       this.relevancyRating = 0;
@@ -64,7 +64,7 @@ export class Review {
     this._id = data._id ?? new Types.ObjectId();
     this.title = data.title ?? '';
     this.semester = data.semester ?? 'First semester';
-    this.grade = data.grade ?? 'P';
+    this.grade = data.grade ?? null;
     this.year = data.year ?? new Date().getFullYear();
     this.overallRating = data.overallRating ?? 0;
     this.relevancyRating = data.relevancyRating ?? 0;
@@ -114,7 +114,7 @@ export class Review {
   // Ensure all rating properties default to 0 if undefined
   ensureDefaults(): void {
     this.semester = this.semester ?? 'First semester';
-    this.grade = this.grade ?? 'P';
+    this.grade = this.grade ?? null;
     this.year = this.year ?? new Date().getFullYear();
     this.overallRating = this.overallRating ?? 0;
     this.relevancyRating = this.relevancyRating ?? 0;

--- a/frontend/src/app/shared/models/v2/review.schema.ts
+++ b/frontend/src/app/shared/models/v2/review.schema.ts
@@ -14,7 +14,7 @@ const BaseReviewSchema = z.object({
     .min(1, { message: 'Description is required' })
     .default('Enter your description'),
   semester: semestersEnum.default('First semester'),
-  grade: gradesEnum.default('P'),
+  grade: gradesEnum.nullable().default(null),
   year: z
     .number()
     .int()

--- a/frontend/src/app/shared/services/api/modify-review.service.ts
+++ b/frontend/src/app/shared/services/api/modify-review.service.ts
@@ -34,7 +34,7 @@ export class ModifyReviewService {
       {
         title: review.title,
         semester: review.semester,
-        grade: review.grade,
+        ...(review.grade ? { grade: review.grade } : {}),
         year: review.year,
         overallRating: review.overallRating,
         relevancyRating: review.relevancyRating,

--- a/frontend/src/app/shared/services/api/post-review.service.ts
+++ b/frontend/src/app/shared/services/api/post-review.service.ts
@@ -17,7 +17,7 @@ export class PostReviewService {
       {
         title: review.title,
         semester: review.semester,
-        grade: review.grade,
+        ...(review.grade ? { grade: review.grade } : {}),
         year: review.year,
         overallRating: review.overallRating,
         relevancyRating: review.relevancyRating,


### PR DESCRIPTION
Closes #252.

The write-review form dropped its grade step, but the stack still forced every review to carry a grade, so new reviews saved as a fake `P`.

## What changed

- Backend [review.model.ts](https://github.com/wiredmonash/monstar/blob/fix-review-grade-null/backend/src/domains/academics/reviews/review.model.ts#L8): drop the `required` constraint on grade, default it to null, keep an enum check so only HD, D, C, P, N are stored when a grade is present.
- Frontend zod [review.schema.ts](https://github.com/wiredmonash/monstar/blob/fix-review-grade-null/frontend/src/app/shared/models/v2/review.schema.ts#L17): grade is nullable with no `P` default.
- Frontend [review.model.ts](https://github.com/wiredmonash/monstar/blob/fix-review-grade-null/frontend/src/app/shared/models/review.model.ts): grade typed as nullable, the three `P` fallbacks now use null.
- Post and update flows ([post-review.service.ts](https://github.com/wiredmonash/monstar/blob/fix-review-grade-null/frontend/src/app/shared/services/api/post-review.service.ts#L20), [modify-review.service.ts](https://github.com/wiredmonash/monstar/blob/fix-review-grade-null/frontend/src/app/shared/services/api/modify-review.service.ts#L37)): send grade only when set, so an unset grade stays null.

## Verification

- New service test in [review.service.test.ts](https://github.com/wiredmonash/monstar/blob/fix-review-grade-null/backend/src/domains/academics/reviews/review.service.test.ts#L92-L108): a review created without a grade stores null. It would have thrown a validation error under the old required model.
- Backend suite: 51 passed.
- Backend and frontend typecheck clean, frontend production build succeeds.

## Notes

- No data migration needed. The historical fake-`P` rows were already backfilled to null (4 in dev_test, 258 in prod).
- Unblocks honest grade data for the grade distribution bars (#250).
