### PR TITLE
Local Redis cache for the Docker environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Contributions are welcome, Monash students preferred. Questions or ideas for new
 
 Pick one of two setups:
 
-- **Docker (recommended):** one command starts the frontend, backend, and a MongoDB instance filled with sample data. No MongoDB Atlas credentials required.
+- **Docker (recommended):** one command starts the frontend, backend, a MongoDB instance filled with sample data, and a local Redis cache. No MongoDB Atlas or Upstash credentials required.
 - **npm:** run the servers directly on your machine against your own MongoDB.
 
 ### Docker

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,6 +38,29 @@ services:
     volumes:
       - mongo-data:/data/db
 
+  # Local stand-in for Upstash: Redis behind serverless-redis-http (SRH),
+  # which speaks the same REST protocol as @upstash/redis. Lets the backend
+  # exercise its real cache path instead of the in-memory fallback.
+  redis:
+    image: redis:8-alpine
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
+      start_interval: 1s
+
+  redis-http:
+    image: hiett/serverless-redis-http:latest
+    environment:
+      SRH_MODE: env
+      SRH_TOKEN: local-dev-token
+      SRH_CONNECTION_STRING: redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+
   backend:
     <<: *backend-base
     env_file: ./backend/.env
@@ -48,6 +71,14 @@ services:
       PORT: '8080'
       DEVELOPMENT: 'true'
       PRODUCTION_MACHINE: 'false'
+      # Pinned for the same reason: real Upstash credentials in .env would
+      # make local containers share (and invalidate) the production cache.
+      # These point at the local redis + SRH pair instead.
+      MONSTAR_SERVERLESS_CACHE_KV_REST_API_URL: http://redis-http:80
+      MONSTAR_SERVERLESS_CACHE_KV_REST_API_TOKEN: local-dev-token
+      MONSTAR_SERVERLESS_CACHE_KV_REST_API_READ_ONLY_TOKEN: ''
+      MONSTAR_SERVERLESS_CACHE_KV_URL: ''
+      MONSTAR_SERVERLESS_CACHE_REDIS_URL: ''
     ports:
       - '8080:8080'
     depends_on:


### PR DESCRIPTION
Follow-up to #276. The compose setup passed backend/.env through untouched, so real Upstash credentials reached the containers and local runs shared the production cache, including invalidations.

## Changes

- [compose.yaml](https://github.com/wiredmonash/monstar/blob/local-redis-cache/compose.yaml) adds a `redis` service (redis:8-alpine) and `redis-http`, the serverless-redis-http proxy that speaks the Upstash REST protocol `@upstash/redis` expects.
- The backend's cache env vars now point at that local pair, and the remaining Upstash vars are pinned empty, so no credential from .env reaches a container.
- The backend exercises its real cache path locally instead of the in-memory fallback in [backend/src/infrastructure/cache/cache.ts](https://github.com/wiredmonash/monstar/blob/local-redis-cache/backend/src/infrastructure/cache/cache.ts).
- [CONTRIBUTING.md](https://github.com/wiredmonash/monstar/blob/local-redis-cache/CONTRIBUTING.md) setup bullet now lists the Redis cache and drops the Upstash credential requirement.

## Verification

- `docker compose up -d`: all services healthy, including the redis pair.
- Hit /api/v2/units/popular twice: 92ms miss, then 11ms hit, with the units:popular key stored in the local Redis container.
- Backend logs show no Redis errors and no "not configured" fallback warning.
- Confirmed `docker compose config` resolves every MONSTAR_SERVERLESS_* variable to the local pair or an empty string.
