### PR TITLE
Replace ObjectId double assertion in review service test with a real conversion

### DIFF
--- a/backend/src/domains/academics/reviews/review.service.test.ts
+++ b/backend/src/domains/academics/reviews/review.service.test.ts
@@ -57,7 +57,7 @@ describe(ReviewService.name, () => {
         contentRating: 5,
         facultyRating: 5,
         description: 'The quick brown fox jumps over the lazy dog',
-        author: author as unknown as Types.ObjectId,
+        author: new Types.ObjectId(author),
       });
 
       // assert


### PR DESCRIPTION
## What

- Swap `author as unknown as Types.ObjectId` for `new Types.ObjectId(author)` in [backend/src/domains/academics/reviews/review.service.test.ts](https://github.com/wiredmonash/monstar/blob/fix-objectid-assertion-review-test/backend/src/domains/academics/reviews/review.service.test.ts#L60).

## Why

- The double assertion made the compiler treat a string as an ObjectId while the runtime value stayed a string.
- The test passed only because Mongoose casts hex strings on save. Any ObjectId method called before save, such as `.equals()` or `.getTimestamp()`, would crash with no compile error.
- `new Types.ObjectId(author)` creates a real ObjectId and drops the assertion.

## Notes

- Only occurrence in the codebase. The other two `as unknown as` casts (supertest set-cookie header, RequestHandler in server.ts) fix wrong library typings and match the runtime type, so they stay.

## Verified

- `vitest run --project services` on the file: 7 pass, 0 fail.
- `tsc --noEmit`: no errors.

Closes #274
