### PR TITLE
Per-path README docs for backend domains and frontend app structure

### DIFF
--- a/backend/src/README.md
+++ b/backend/src/README.md
@@ -1,0 +1,29 @@
+# Backend source
+
+Express API laid out as domain-driven bounded contexts. [server.ts](server.ts) wires it all together: middleware (dev CORS, CSRF, cookies), a DB-connect guard on every request, route mounting, and Swagger. [bootstrap.ts](bootstrap.ts) loads env vars and registers the path aliases, so it stays the first import in [server.ts](server.ts).
+
+## Layout
+
+- [domains/](domains/): business logic, one folder per bounded context. Each context has its own README.
+- [infrastructure/](infrastructure/): clients for external systems (MongoDB, Redis cache, Cloudinary storage, Gemini).
+- [shared/](shared/): cross-domain plumbing (error classes and middleware, `asyncHandler`, test setup).
+- [docs/](docs/): Swagger generation. [swagger.json](docs/swagger.json) is generated output; dev boots rewrite it.
+- [scripts/](scripts/): one-off tooling (sitemap generation, dev database seeding).
+
+## Path aliases
+
+`@domains/*`, `@infrastructure/*`, `@shared/*`, `@docs/*` (see [tsconfig.json](../tsconfig.json)). There are no per-layer aliases like `@models`.
+
+## Import rules
+
+- Each subdomain publishes its API through its `index.ts`. Cross-subdomain imports go through that barrel: `import { UnitRepository } from '@domains/academics/units'`. Import types with `import type`.
+- Exception: `*.model.ts` files import other domains' models from the concrete file (`@domains/identity/users/user.model`), never the barrel. The test setup ([shared/testing/services.setup.ts](shared/testing/services.setup.ts)) eagerly loads every model via `import.meta.glob`; a barrel import would drag that subdomain's services into the eager load and bind them before `vi.mock` runs. Don't tidy these to barrels.
+- academics and identity form an accepted cycle (reviews reference users and notifications for the user-deletion cascade). It stays safe because the cross-domain calls happen inside methods at call time, not at module load.
+
+## Adding an endpoint
+
+1. Pick the bounded context, or add a subdomain folder under the right one.
+2. Follow the file convention: `x.model.ts`, `x.repository.ts`, `x.service.ts`, `x.controller.ts`, `x.types.ts`, `xs.v2.routes.ts`, and export the lot from `index.ts`.
+3. Mount the router in [server.ts](server.ts).
+
+`*.v1.*` files hold legacy v1-only logic so retiring v1 is one sweep. Issue [#208](https://github.com/wiredmonash/monstar/issues/208) tracks the v1 to v2 conversion.

--- a/backend/src/domains/academics/README.md
+++ b/backend/src/domains/academics/README.md
@@ -1,0 +1,15 @@
+# Academics
+
+Units of study and what students say about them.
+
+- [units](units/): unit catalogue, tags, filtering and sorting, AI-generated overviews.
+  Routes: `/api/v1/units`, `/api/v2/units`
+- [reviews](reviews/): student reviews of units.
+  Routes: `/api/v2/reviews`
+- [setu](setu/): scraped SETU survey results.
+  Routes: none mounted
+
+Notes:
+
+- [setu](setu/) defines [setus.v1.routes.ts](setu/setus.v1.routes.ts) but [server.ts](../../server.ts) never mounts it. The SETU model feeds the [AI overview service](units/aiOverview.service.ts) and the [sitemap script](../../scripts/generateSitemap.ts), and `enableSetuCards` is off in every frontend environment.
+- reviews referencing identity (users, notifications) is an accepted cycle; see the import rules in the [backend source README](../../README.md).

--- a/backend/src/domains/identity/README.md
+++ b/backend/src/domains/identity/README.md
@@ -1,0 +1,13 @@
+# Identity
+
+Who the user is and what the platform tells them.
+
+- [users](users/): user accounts, Google auth, JWT tokens, avatars.
+  Routes: `/api/v1/auth`, `/api/v2/users`
+- [notifications](notifications/): per-user notifications.
+  Routes: `/api/v1/notifications`
+
+Notes:
+
+- Auth middleware lives in [users](users/), not in shared: import `verifyToken`, `verifyUser`, and `verifyAdmin` from `@domains/identity/users` (defined in [auth.middleware.ts](users/auth.middleware.ts)).
+- The [User schema](users/user.model.ts) stores the Google account id as `googleID` (capital D). Keep that casing in queries and projections.

--- a/backend/src/domains/platform/README.md
+++ b/backend/src/domains/platform/README.md
@@ -1,0 +1,13 @@
+# Platform
+
+Operational glue that isn't a business domain.
+
+- [github](github/): repo contributors fetched from the GitHub API.
+  Routes: `/api/v1/github`
+- [admin](admin/): dev-only ops endpoints.
+  Routes: `/api/admin`, mounted only when `DEVELOPMENT=true` on a non-production machine
+
+Notes:
+
+- [github](github/) uses a gateway: [github.gateway.ts](github/github.gateway.ts) wraps axios and the service stays HTTP-free. Tests mock the default axios export, so keep the default instance rather than `axios.create()`.
+- [admin](admin/) has no repository or service on purpose; the controller does the work.

--- a/backend/src/domains/recruitment/README.md
+++ b/backend/src/domains/recruitment/README.md
@@ -1,0 +1,10 @@
+# Recruitment
+
+The jobs board.
+
+- [jobs](jobs/): job postings synced from Notion via [notion.gateway.ts](jobs/notion.gateway.ts).
+  Routes: `/api/v2/jobs`
+- [orgLogo](orgLogo/): cached organisation logos for job cards.
+  Routes: served through the jobs router
+
+[orgLogo](orgLogo/) has no routes file of its own; [jobs.v2.routes.ts](jobs/jobs.v2.routes.ts) exposes it.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,4 +26,4 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
 
-fsdfhdskljsffjsdh
+For the layout of `src/app/` and project conventions, see [src/app/README.md](src/app/README.md).

--- a/frontend/src/app/README.md
+++ b/frontend/src/app/README.md
@@ -1,0 +1,21 @@
+# App structure
+
+Angular 18, standalone components only (no NgModules).
+
+- [routes/](routes/): one folder per page, registered in [app.routes.ts](app.routes.ts).
+- [shared/components/](shared/components/): reusable UI (navbar, footer, cards, rating, notifications).
+- [shared/services/](shared/services/): injectable singletons. [api/](shared/services/api/) wraps backend endpoints, [ui/](shared/services/ui/) holds UI-only services, the root holds app-wide ones (auth, csrf, viewport).
+- [shared/models/](shared/models/): legacy v1 model classes at the root; [v2/](shared/models/v2/) holds the Zod schemas and inferred types the `@models` alias points at.
+- [shared/interceptors/](shared/interceptors/): HTTP interceptors for auth refresh and CSRF tokens.
+- [shared/pipes/](shared/pipes/), [shared/constants/](shared/constants/), [shared/utils/](shared/utils/): what the names say.
+
+## Path aliases
+
+From [tsconfig.json](../../tsconfig.json): `@routes`, `@components`, `@services`, `@pipes`, and `@models` (which resolves to [shared/models/v2](shared/models/v2/), not the legacy root).
+
+## Conventions
+
+- New page: add a folder under [routes/](routes/) and register the component in [app.routes.ts](app.routes.ts).
+- Set `standalone: true` explicitly on components, directives, and pipes. Implicit standalone starts in Angular 19 and omitting it here breaks the build.
+- Take API URLs from the [environments/](../environments/) constants (`apiUrl`, `setuUrl`, and friends); don't hardcode `/api/v1` in services.
+- The Angular 18 rules in [AGENTS.md](../../../AGENTS.md) cover which newer-Angular APIs don't exist here.


### PR DESCRIPTION
Closes #281

- Adds READMEs at [backend/src](https://github.com/wiredmonash/monstar/blob/per-path-readmes/backend/src/README.md), the four bounded contexts ([academics](https://github.com/wiredmonash/monstar/blob/per-path-readmes/backend/src/domains/academics/README.md), [identity](https://github.com/wiredmonash/monstar/blob/per-path-readmes/backend/src/domains/identity/README.md), [platform](https://github.com/wiredmonash/monstar/blob/per-path-readmes/backend/src/domains/platform/README.md), [recruitment](https://github.com/wiredmonash/monstar/blob/per-path-readmes/backend/src/domains/recruitment/README.md)), and [frontend/src/app](https://github.com/wiredmonash/monstar/blob/per-path-readmes/frontend/src/app/README.md).
- Each covers what the path holds, the boundary rules (imports, routes), and where new code goes.
- File and directory mentions inside the READMEs are relative links, clickable on GitHub.
- Replaces the gibberish trailing line in [frontend/README.md](https://github.com/wiredmonash/monstar/blob/per-path-readmes/frontend/README.md) with a link to the new app README.
