### PR TITLE
Add account deletion to the profile panel

### DIFF
--- a/backend/src/domains/identity/users/user.service.test.ts
+++ b/backend/src/domains/identity/users/user.service.test.ts
@@ -1,5 +1,11 @@
+import mongoose from 'mongoose';
+
 import { User, UserService } from '@domains/identity/users';
-import { Error403Forbidden, Error409Conflict } from '@shared/errors/errors';
+import {
+  Error403Forbidden,
+  Error404NotFound,
+  Error409Conflict,
+} from '@shared/errors/errors';
 
 const { mockVerifyIdToken } = vi.hoisted(() => ({
   mockVerifyIdToken: vi.fn(),
@@ -153,6 +159,85 @@ describe(UserService.name, () => {
       await expect(
         UserService.googleAuthenticate(fakeIdTokenString)
       ).rejects.toThrow(Error409Conflict);
+    });
+  });
+
+  // Account deletion
+
+  describe(UserService.deleteUser.name, () => {
+    it('lets a user delete their own account', async () => {
+      const user = await User.create({
+        email: 'selfdel@student.monash.edu',
+        username: 'selfdel',
+        verified: true,
+      });
+
+      await UserService.deleteUser(user._id.toString(), user._id.toString());
+
+      expect(await User.findById(user._id)).toBeNull();
+    });
+
+    it('lets an admin delete another user', async () => {
+      const admin = await User.create({
+        email: 'admin@monash.edu',
+        username: 'admin',
+        admin: true,
+        verified: true,
+      });
+      const target = await User.create({
+        email: 'target@student.monash.edu',
+        username: 'target',
+        verified: true,
+      });
+
+      await UserService.deleteUser(admin._id.toString(), target._id.toString());
+
+      expect(await User.findById(target._id)).toBeNull();
+    });
+
+    it('throws Error403Forbidden when a non-admin deletes another user', async () => {
+      const caller = await User.create({
+        email: 'caller@student.monash.edu',
+        username: 'caller',
+        verified: true,
+      });
+      const target = await User.create({
+        email: 'other@student.monash.edu',
+        username: 'other',
+        verified: true,
+      });
+
+      await expect(
+        UserService.deleteUser(caller._id.toString(), target._id.toString())
+      ).rejects.toThrow(Error403Forbidden);
+
+      expect(await User.findById(target._id)).not.toBeNull();
+    });
+
+    it('throws Error404NotFound when the requesting user does not exist', async () => {
+      const target = await User.create({
+        email: 'stillhere@student.monash.edu',
+        username: 'stillhere',
+        verified: true,
+      });
+      const ghostId = new mongoose.Types.ObjectId().toString();
+
+      await expect(
+        UserService.deleteUser(ghostId, target._id.toString())
+      ).rejects.toThrow(Error404NotFound);
+    });
+
+    it('throws Error404NotFound when the target user does not exist', async () => {
+      const caller = await User.create({
+        email: 'requester@student.monash.edu',
+        username: 'requester',
+        verified: true,
+      });
+      const missingId = new mongoose.Types.ObjectId().toString();
+
+      await expect(
+        UserService.deleteUser(caller._id.toString(), missingId)
+      ).rejects.toThrow(Error404NotFound);
     });
   });
 });

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -102,6 +102,9 @@
           "options": {
             "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
+            "stylePreprocessorOptions": {
+              "includePaths": ["src/app/styles"]
+            },
             "assets": [
               {
                 "glob": "**/*",

--- a/frontend/src/app/routes/user-profile/delete-account-button/delete-account-button.component.html
+++ b/frontend/src/app/routes/user-profile/delete-account-button/delete-account-button.component.html
@@ -1,0 +1,9 @@
+<div
+  class="delete-account-button-container"
+  [class.confirming]="confirming()"
+  (click)="onClick()"
+  (mouseleave)="scheduleReset()"
+  (mouseenter)="cancelReset()"
+>
+  {{ confirming() ? 'Are you sure?' : 'Delete account' }}
+</div>

--- a/frontend/src/app/routes/user-profile/delete-account-button/delete-account-button.component.scss
+++ b/frontend/src/app/routes/user-profile/delete-account-button/delete-account-button.component.scss
@@ -1,10 +1,9 @@
 @import 'mixins';
-@import 'variables';
 
-.logout-button-container {
+.delete-account-button-container {
   display: flex;
   justify-content: center;
-  background-color: $bg-dark-color;
+  background-color: rgb(197, 54, 54);
   border-radius: 1rem;
   padding: 1rem;
 
@@ -13,7 +12,7 @@
     @include button-hover;
   }
 
-  .text-container {
-    
+  &.confirming {
+    background-color: rgb(150, 30, 30);
   }
 }

--- a/frontend/src/app/routes/user-profile/delete-account-button/delete-account-button.component.spec.ts
+++ b/frontend/src/app/routes/user-profile/delete-account-button/delete-account-button.component.spec.ts
@@ -1,0 +1,54 @@
+import { DeleteAccountButtonComponent } from './delete-account-button.component';
+
+describe('DeleteAccountButtonComponent', () => {
+  let component: DeleteAccountButtonComponent;
+
+  beforeEach(() => {
+    component = new DeleteAccountButtonComponent();
+  });
+
+  it('arms the confirm on the first click without emitting', () => {
+    const spy = jasmine.createSpy('confirmed');
+    component.confirmed.subscribe(spy);
+
+    component.onClick();
+
+    expect(component.confirming()).toBeTrue();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('emits confirmed on the second click', () => {
+    const spy = jasmine.createSpy('confirmed');
+    component.confirmed.subscribe(spy);
+
+    component.onClick(); // arm
+    component.onClick(); // confirm
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the confirm armed briefly after mouse leave, then disarms', () => {
+    jasmine.clock().install();
+    component.onClick();
+
+    component.scheduleReset();
+    jasmine.clock().tick(1000);
+    expect(component.confirming()).toBeTrue(); // still armed during grace period
+
+    jasmine.clock().tick(3000);
+    expect(component.confirming()).toBeFalse(); // disarmed after the delay
+    jasmine.clock().uninstall();
+  });
+
+  it('cancels the pending reset when the mouse returns', () => {
+    jasmine.clock().install();
+    component.onClick();
+
+    component.scheduleReset();
+    component.cancelReset();
+    jasmine.clock().tick(5000);
+
+    expect(component.confirming()).toBeTrue();
+    jasmine.clock().uninstall();
+  });
+});

--- a/frontend/src/app/routes/user-profile/delete-account-button/delete-account-button.component.ts
+++ b/frontend/src/app/routes/user-profile/delete-account-button/delete-account-button.component.ts
@@ -1,0 +1,52 @@
+import {
+  Component,
+  EventEmitter,
+  OnDestroy,
+  Output,
+  signal,
+} from '@angular/core';
+
+/** How long the armed "Are you sure?" state lingers after the mouse leaves. */
+const RESET_DELAY_MS = 3000;
+
+@Component({
+  selector: 'app-delete-account-button',
+  standalone: true,
+  templateUrl: './delete-account-button.component.html',
+  styleUrl: './delete-account-button.component.scss',
+})
+export class DeleteAccountButtonComponent implements OnDestroy {
+  @Output() confirmed = new EventEmitter<void>();
+
+  /** First click arms the confirm; second click emits and deletes. */
+  confirming = signal(false);
+
+  private resetTimer?: ReturnType<typeof setTimeout>;
+
+  onClick() {
+    clearTimeout(this.resetTimer);
+    if (this.confirming()) {
+      this.confirmed.emit();
+    } else {
+      this.confirming.set(true);
+    }
+  }
+
+  /** Mouse left: disarm, but only after a grace period. */
+  scheduleReset() {
+    clearTimeout(this.resetTimer);
+    this.resetTimer = setTimeout(
+      () => this.confirming.set(false),
+      RESET_DELAY_MS
+    );
+  }
+
+  /** Mouse came back in time: keep it armed. */
+  cancelReset() {
+    clearTimeout(this.resetTimer);
+  }
+
+  ngOnDestroy() {
+    clearTimeout(this.resetTimer);
+  }
+}

--- a/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.html
+++ b/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.html
@@ -19,5 +19,8 @@
 
   @if (state.isCurrentUser) {
     <app-logout-button (click)="logoutPressed.emit()"></app-logout-button>
+    <app-delete-account-button
+      (confirmed)="deleteAccountPressed.emit()"
+    ></app-delete-account-button>
   }
 </div>

--- a/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.ts
+++ b/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.ts
@@ -1,15 +1,17 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { DeleteAccountButtonComponent } from '../delete-account-button/delete-account-button.component';
 import { LogoutButtonComponent } from '../logout-button/logout-button.component';
 import { State } from '../user-profile.state';
 
 @Component({
   selector: 'app-profile-panel',
   standalone: true,
-  imports: [LogoutButtonComponent],
+  imports: [LogoutButtonComponent, DeleteAccountButtonComponent],
   templateUrl: './profile-panel.component.html',
   styleUrl: './profile-panel.component.scss',
 })
 export class ProfilePanelComponent {
   @Input({ required: true }) state!: State;
   @Output() logoutPressed = new EventEmitter<void>();
+  @Output() deleteAccountPressed = new EventEmitter<void>();
 }

--- a/frontend/src/app/routes/user-profile/user-profile.component.html
+++ b/frontend/src/app/routes/user-profile/user-profile.component.html
@@ -5,7 +5,11 @@
 <div class="page-container">
   <!-- Left profile panel -->
   @if (state) {
-    <app-profile-panel [state]="state" (logoutPressed)="logout()" />
+    <app-profile-panel
+      [state]="state"
+      (logoutPressed)="logout()"
+      (deleteAccountPressed)="deleteAccount()"
+    />
   } @else {
     <div class="profile-panel-skeleton">
       <div class="skeleton-header">

--- a/frontend/src/app/routes/user-profile/user-profile.component.ts
+++ b/frontend/src/app/routes/user-profile/user-profile.component.ts
@@ -147,4 +147,13 @@ export class UserProfileComponent {
       this.router.navigate(['/']);
     });
   }
+
+  deleteAccount() {
+    const userId = this.userService.getId();
+    if (!userId) return;
+
+    this.userService.deleteAccount(userId).subscribe(() => {
+      this.router.navigate(['/']);
+    });
+  }
 }

--- a/frontend/src/app/shared/services/api/user.service.spec.ts
+++ b/frontend/src/app/shared/services/api/user.service.spec.ts
@@ -56,6 +56,21 @@ describe('UserService session state', () => {
     expect(service.currentUserValue).toBeNull();
   });
 
+  it('deletes the account and clears the current user', () => {
+    service.validateSession().subscribe();
+    httpMock
+      .expectOne(`${v2}/users/validate`)
+      .flush({ message: 'Authenticated', data: user });
+    expect(service.currentUserValue).toEqual(user);
+
+    service.deleteAccount(user._id).subscribe();
+    const req = httpMock.expectOne(`${v2}/users/delete/${user._id}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush({ message: 'User successfully deleted' });
+
+    expect(service.currentUserValue).toBeNull();
+  });
+
   it('clearSession drops the user without a backend call', () => {
     service.validateSession().subscribe();
     httpMock

--- a/frontend/src/app/shared/services/api/user.service.ts
+++ b/frontend/src/app/shared/services/api/user.service.ts
@@ -158,6 +158,18 @@ export class UserService {
       );
   }
 
+  deleteAccount(userId: string): Observable<{ message: string }> {
+    return this.http
+      .delete<{
+        message: string;
+      }>(`${this.url}/delete/${userId}`, { withCredentials: true })
+      .pipe(
+        tap(() => {
+          this._currentUser.next(null);
+        })
+      );
+  }
+
   logout(): Observable<{ message: string }> {
     return this.http
       .post<{


### PR DESCRIPTION
## What

- Adds a delete-account control to the profile panel, wired to DELETE /api/v2/users/delete/:userId.
- Two-click confirm: Delete account, then Are you sure?, then it deletes, clears the session, and redirects home.
- The armed Are you sure? state lingers 3 seconds after the mouse leaves, so a small mouse twitch does not reset it. Moving back or clicking cancels the pending reset.
- Delete is red. Logout is now neutral.

## Why

- The endpoint existed but nothing called it, so users could not delete their own account.

## Notes

- The server cascades the delete (reviews, notifications, avatar, reaction counts) and authorises self or admin, so the client sends the current user id and clears local state.
- No backend code changed. The endpoint and its route tests were already there.

## Tests

- Frontend: a UserService.deleteAccount service test, plus the button confirm and delayed-reset behaviour. 22 pass.
- Backend: added UserService.deleteUser service tests for self, admin, 403, and both 404 cases. Full suite 66 pass.

## Verified

- Drove the flow end to end on a preview server against a throwaway seeded user with a forged session. Delete account, Are you sure?, redirect home, and the user was gone from the database. No real account touched.

Closes #290
Follow-up filed: #293 (7-day retention for rollback).