### PR TITLE
Add username editing to the profile panel

### DIFF
--- a/backend/src/domains/identity/users/user.service.ts
+++ b/backend/src/domains/identity/users/user.service.ts
@@ -2,13 +2,13 @@ import { OAuth2Client } from 'google-auth-library';
 import jwt from 'jsonwebtoken';
 
 import { cloudinary } from '@infrastructure/storage/cloudinary';
-import type { Id } from '@shared/types';
 import { CreateError } from '@shared/errors/error';
 import {
-  Error409Conflict,
   Error403Forbidden,
   Error404NotFound,
+  Error409Conflict,
 } from '@shared/errors/errors';
+import type { Id } from '@shared/types';
 import { getErrorMessage } from '@shared/utilities/getErrorMessage';
 
 import TokenProvider from './token.service';
@@ -198,7 +198,15 @@ class UserService {
 
     if (!username) throw CreateError(400, 'Username is required to update');
 
-    targetUser.username = username;
+    const trimmed = username.trim();
+    if (trimmed.length < 3 || trimmed.length > 20)
+      throw CreateError(400, 'Username must be between 3 and 20 characters');
+
+    const existing = await UserRepository.findByUsername(trimmed);
+    if (existing && existing._id.toString() !== targetUser._id.toString())
+      throw new Error409Conflict(`Username '${trimmed}' is already taken`);
+
+    targetUser.username = trimmed;
     await targetUser.save();
 
     return targetUser;

--- a/backend/src/domains/identity/users/users.routes.test.ts
+++ b/backend/src/domains/identity/users/users.routes.test.ts
@@ -6,7 +6,7 @@ import request from 'supertest';
 
 import { TokenProvider } from '@domains/identity/users';
 
-import { getCsrf, accessTokenCookie } from '@shared/testing/helpers';
+import { accessTokenCookie, getCsrf } from '@shared/testing/helpers';
 
 vi.mock('multer', () => {
   const multer = () => ({
@@ -281,8 +281,18 @@ describe('PUT /api/v2/users/update/:userId (username, self or admin)', () => {
     const callerId = new mongoose.Types.ObjectId();
     const targetId = new mongoose.Types.ObjectId();
     await mongoose.connection.collection('users').insertMany([
-      { _id: callerId, username: 'caller', email: 'c@example.com', admin: false },
-      { _id: targetId, username: 'target', email: 't@example.com', admin: false },
+      {
+        _id: callerId,
+        username: 'caller',
+        email: 'c@example.com',
+        admin: false,
+      },
+      {
+        _id: targetId,
+        username: 'target',
+        email: 't@example.com',
+        admin: false,
+      },
     ]);
 
     const { token, cookies } = await getCsrf(global.app);
@@ -307,6 +317,54 @@ describe('PUT /api/v2/users/update/:userId (username, self or admin)', () => {
       .send({ username: 'x' });
 
     expect(res.status).toBe(401);
+  });
+
+  it('returns 409 when the username is already taken', async () => {
+    const callerId = new mongoose.Types.ObjectId();
+    const otherId = new mongoose.Types.ObjectId();
+    await mongoose.connection.collection('users').insertMany([
+      { _id: callerId, username: 'mine', email: 'm@example.com', admin: false },
+      { _id: otherId, username: 'taken', email: 'o@example.com', admin: false },
+    ]);
+
+    const { token, cookies } = await getCsrf(global.app);
+    const res = await request(global.app)
+      .put(`/api/v2/users/update/${callerId}`)
+      .set(
+        'Cookie',
+        [...cookies, accessTokenCookie(callerId.toString())].join('; ')
+      )
+      .set('x-csrf-token', token)
+      .send({ username: 'taken' });
+
+    expect(res.status).toBe(409);
+
+    const stored = await mongoose.connection
+      .collection('users')
+      .findOne({ _id: callerId });
+    expect(stored?.username).toBe('mine');
+  });
+
+  it('returns 400 when the username exceeds the length limit', async () => {
+    const userId = new mongoose.Types.ObjectId();
+    await mongoose.connection.collection('users').insertOne({
+      _id: userId,
+      username: 'shortname',
+      email: 'len@example.com',
+      admin: false,
+    });
+
+    const { token, cookies } = await getCsrf(global.app);
+    const res = await request(global.app)
+      .put(`/api/v2/users/update/${userId}`)
+      .set(
+        'Cookie',
+        [...cookies, accessTokenCookie(userId.toString())].join('; ')
+      )
+      .set('x-csrf-token', token)
+      .send({ username: 'a'.repeat(21) });
+
+    expect(res.status).toBe(400);
   });
 });
 
@@ -342,8 +400,18 @@ describe('DELETE /api/v2/users/delete/:userId (self or admin)', () => {
     const callerId = new mongoose.Types.ObjectId();
     const targetId = new mongoose.Types.ObjectId();
     await mongoose.connection.collection('users').insertMany([
-      { _id: callerId, username: 'delcaller', email: 'dc@example.com', admin: false },
-      { _id: targetId, username: 'deltarget', email: 'dt@example.com', admin: false },
+      {
+        _id: callerId,
+        username: 'delcaller',
+        email: 'dc@example.com',
+        admin: false,
+      },
+      {
+        _id: targetId,
+        username: 'deltarget',
+        email: 'dt@example.com',
+        admin: false,
+      },
     ]);
 
     const { token, cookies } = await getCsrf(global.app);

--- a/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.html
+++ b/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.html
@@ -8,8 +8,11 @@
           class="username username-input"
           [value]="draft()"
           [style.width.px]="editWidth()"
-          [disabled]="saving()"
           maxlength="20"
+          name="profile-username-edit"
+          autocomplete="off"
+          data-bwignore
+          readonly
           (input)="draft.set($any($event.target).value)"
           (keydown.enter)="save()"
           (keydown.escape)="cancel()"

--- a/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.html
+++ b/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.html
@@ -1,12 +1,43 @@
 <div class="profile-panel">
   <div class="user-header">
     <img class="profile-img" [src]="state.profileImg" />
-    <span class="username">{{ state.username ?? 'username not found' }}</span>
+    <div class="name-block">
+      @if (editing()) {
+        <input
+          #usernameInput
+          class="username username-input"
+          [value]="draft()"
+          [style.width.px]="editWidth()"
+          [disabled]="saving()"
+          maxlength="20"
+          (input)="draft.set($any($event.target).value)"
+          (keydown.enter)="save()"
+          (keydown.escape)="cancel()"
+          (blur)="save()"
+        />
+      } @else {
+        <span
+          #usernameSpan
+          class="username"
+          [class.editable]="state.isCurrentUser"
+          (click)="startEdit()"
+        >
+          {{ state.username ?? 'username not found' }}
+        </span>
+      }
+      @if (state.authcate) {
+        <span class="authcate">{{ state.authcate }}</span>
+      }
+    </div>
   </div>
   @if (state.isCurrentUser) {
-    <p style="text-align: center; color: grey">
-      More personalisation stuff coming here soon!
-    </p>
+    <div class="status-line">
+      @if (error()) {
+        <span class="edit-error">{{ error() }}</span>
+      } @else if (!editing()) {
+        <span class="edit-hint">Click your username to change it.</span>
+      }
+    </div>
   }
 
   <!-- <p class="bio">

--- a/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.scss
+++ b/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.scss
@@ -33,9 +33,64 @@
       object-position: center;
     }
 
+    .name-block {
+      display: flex;
+      align-items: baseline;
+      gap: 0.5rem;
+      min-width: 0;
+    }
+
+    // Shared box metrics so the span↔input swap never shifts anything.
     .username {
       font-size: 1.2rem;
+      padding: 0;
+      margin: 0;
+      border: 0;
+      line-height: 1.4;
+
+      &.editable {
+        cursor: text;
+
+        &:hover {
+          text-decoration: underline dotted;
+          text-underline-offset: 3px;
+        }
+      }
     }
+
+    .username-input {
+      color: inherit;
+      font: inherit;
+      background-color: $bg-dark-color;
+      border-radius: 4px;
+      outline: 2px solid $primary-color;
+      box-sizing: border-box;
+
+      &:disabled {
+        opacity: 0.6;
+      }
+    }
+
+    .authcate {
+      color: grey;
+      font-size: 0.9rem;
+      flex-shrink: 0;
+      user-select: none;
+    }
+  }
+
+  // Reserved so toggling hint/error/edit never shifts the content below.
+  .status-line {
+    min-height: 1.2rem;
+    font-size: 0.85rem;
+  }
+
+  .edit-error {
+    color: #ff6b6b;
+  }
+
+  .edit-hint {
+    color: grey;
   }
 
   .field {

--- a/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.scss
+++ b/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.scss
@@ -37,10 +37,8 @@
       display: flex;
       align-items: baseline;
       gap: 0.5rem;
-      min-width: 0;
     }
 
-    // Shared box metrics so the span↔input swap never shifts anything.
     .username {
       font-size: 1.2rem;
       padding: 0;
@@ -65,10 +63,7 @@
       border-radius: 4px;
       outline: 2px solid $primary-color;
       box-sizing: border-box;
-
-      &:disabled {
-        opacity: 0.6;
-      }
+      padding: 0 6px;
     }
 
     .authcate {
@@ -79,7 +74,6 @@
     }
   }
 
-  // Reserved so toggling hint/error/edit never shifts the content below.
   .status-line {
     min-height: 1.2rem;
     font-size: 0.85rem;

--- a/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.ts
+++ b/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.ts
@@ -1,4 +1,15 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+  inject,
+  signal,
+} from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { UserService } from '@services/api/user.service';
 import { LogoutButtonComponent } from '../logout-button/logout-button.component';
 import { State } from '../user-profile.state';
 
@@ -11,5 +22,61 @@ import { State } from '../user-profile.state';
 })
 export class ProfilePanelComponent {
   @Input({ required: true }) state!: State;
+  @Output() usernameSaved = new EventEmitter<string>();
   @Output() logoutPressed = new EventEmitter<void>();
+
+  @ViewChild('usernameSpan') usernameSpan?: ElementRef<HTMLElement>;
+  @ViewChild('usernameInput') usernameInput?: ElementRef<HTMLInputElement>;
+
+  private userService = inject(UserService);
+
+  editing = signal(false);
+  draft = signal('');
+  error = signal<string | null>(null);
+  saving = signal(false);
+  // Pins the input to the display text's width so nothing shifts on edit.
+  editWidth = signal(0);
+
+  startEdit() {
+    if (!this.state.isCurrentUser || this.saving()) return;
+    this.editWidth.set(this.usernameSpan?.nativeElement.offsetWidth ?? 0);
+    this.draft.set(this.state.username ?? '');
+    this.error.set(null);
+    this.editing.set(true);
+    setTimeout(() => this.usernameInput?.nativeElement.select());
+  }
+
+  cancel() {
+    this.draft.set(this.state.username ?? '');
+    this.error.set(null);
+    this.editing.set(false);
+  }
+
+  save() {
+    // Guard re-entry: removing/disabling the input fires a stray blur→save
+    // after a save has already started or finished.
+    if (this.saving() || !this.editing()) return;
+
+    const next = this.draft().trim();
+    const userId = this.state.user?._id;
+
+    if (!next || next === this.state.username || !userId) {
+      this.cancel();
+      return;
+    }
+
+    this.error.set(null);
+    this.saving.set(true);
+    this.userService.updateUsername(userId, next).subscribe({
+      next: (newUsername) => {
+        this.saving.set(false);
+        this.editing.set(false);
+        this.usernameSaved.emit(newUsername);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.saving.set(false);
+        this.error.set(err.error?.message ?? 'Could not update username');
+      },
+    });
+  }
 }

--- a/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.ts
+++ b/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.ts
@@ -2,9 +2,11 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  Injector,
   Input,
   Output,
   ViewChild,
+  afterNextRender,
   inject,
   signal,
 } from '@angular/core';
@@ -29,12 +31,12 @@ export class ProfilePanelComponent {
   @ViewChild('usernameInput') usernameInput?: ElementRef<HTMLInputElement>;
 
   private userService = inject(UserService);
+  private injector = inject(Injector);
 
   editing = signal(false);
   draft = signal('');
   error = signal<string | null>(null);
   saving = signal(false);
-  // Pins the input to the display text's width so nothing shifts on edit.
   editWidth = signal(0);
 
   startEdit() {
@@ -43,7 +45,15 @@ export class ProfilePanelComponent {
     this.draft.set(this.state.username ?? '');
     this.error.set(null);
     this.editing.set(true);
-    setTimeout(() => this.usernameInput?.nativeElement.select());
+    afterNextRender(
+      () => {
+        const el = this.usernameInput?.nativeElement;
+        el?.focus();
+        el?.select();
+        if (el) el.readOnly = false;
+      },
+      { injector: this.injector }
+    );
   }
 
   cancel() {
@@ -53,8 +63,6 @@ export class ProfilePanelComponent {
   }
 
   save() {
-    // Guard re-entry: removing/disabling the input fires a stray blur→save
-    // after a save has already started or finished.
     if (this.saving() || !this.editing()) return;
 
     const next = this.draft().trim();

--- a/frontend/src/app/routes/user-profile/user-profile.component.html
+++ b/frontend/src/app/routes/user-profile/user-profile.component.html
@@ -5,7 +5,11 @@
 <div class="page-container">
   <!-- Left profile panel -->
   @if (state) {
-    <app-profile-panel [state]="state" (logoutPressed)="logout()" />
+    <app-profile-panel
+      [state]="state"
+      (usernameSaved)="onUsernameSaved($event)"
+      (logoutPressed)="logout()"
+    />
   } @else {
     <div class="profile-panel-skeleton">
       <div class="skeleton-header">

--- a/frontend/src/app/routes/user-profile/user-profile.component.ts
+++ b/frontend/src/app/routes/user-profile/user-profile.component.ts
@@ -91,6 +91,7 @@ export class UserProfileComponent {
     }),
     map(({ user, currUser, reviews }) => ({
       username: user?.username ?? null,
+      authcate: user?.email?.slice(0, 8) ?? null,
       user: user ?? null,
       profileImg: user?.profileImg ?? DEFAULT_PROFILE_IMG,
       isCurrentUser:
@@ -140,6 +141,15 @@ export class UserProfileComponent {
         })
       )
       .subscribe();
+  }
+
+  onUsernameSaved(newUsername: string) {
+    this.messageService.add({
+      severity: 'success',
+      summary: 'Username updated!',
+      detail: `You are now known as ${newUsername}`,
+    });
+    this.router.navigate(['/user', newUsername]);
   }
 
   logout() {

--- a/frontend/src/app/routes/user-profile/user-profile.state.ts
+++ b/frontend/src/app/routes/user-profile/user-profile.state.ts
@@ -3,6 +3,7 @@ import { IUser } from "@models/user.schema";
 
 export interface State {
   username: string | null;
+  authcate: string | null;
   user: IUser | null;
   profileImg: string;
   isCurrentUser: boolean;

--- a/frontend/src/app/shared/services/api/user.service.ts
+++ b/frontend/src/app/shared/services/api/user.service.ts
@@ -128,6 +128,21 @@ export class UserService {
     return this.http.get<IUser>(`${this.url}/${username}`);
   }
 
+  updateUsername(userId: string, username: string): Observable<string> {
+    return this.http
+      .put<{ message: string; username: string }>(
+        `${this.url}/update/${userId}`,
+        { username }
+      )
+      .pipe(
+        map((res) => res.username),
+        tap((newUsername) => {
+          const user = this._currentUser.value;
+          if (user) this._currentUser.next({ ...user, username: newUsername });
+        })
+      );
+  }
+
   googleAuthenticate(idToken: string): Observable<IUser> {
     return this.http
       .post<UserResponse>(


### PR DESCRIPTION
## What

- Click your username in the profile panel to edit it, wired to `PUT /api/v2/users/update/:userId`.
- Shows your authcate (first 8 characters of your email) greyed to the right of the username. It is not selectable.
- Rejects usernames that are already taken, with an inline error.
- Enforces a 3 to 20 character length, on the server and via the input.

## Frontend

- [profile-panel.component.ts](https://github.com/wiredmonash/monstar/blob/edit-username-profile/frontend/src/app/routes/user-profile/profile-panel/profile-panel.component.ts): click-to-edit with signals, inline validation error, and a re-entry guard so a stray blur cannot fire a second save.
- No-jump edit: pins the input to the display text's width so the authcate beside it never shifts. A reserved status line keeps the content below from moving.
- [user.service.ts](https://github.com/wiredmonash/monstar/blob/edit-username-profile/frontend/src/app/shared/services/api/user.service.ts): new `updateUsername` that patches the current user so the name refreshes without a reload.
- [user-profile.component.ts](https://github.com/wiredmonash/monstar/blob/edit-username-profile/frontend/src/app/routes/user-profile/user-profile.component.ts): on save, toast and navigate to the new `/user/<name>` URL.

## Backend

- [user.service.ts](https://github.com/wiredmonash/monstar/blob/edit-username-profile/backend/src/domains/identity/users/user.service.ts#L199-L209): `updateUser` now trims the username, checks the 3 to 20 length, and returns 409 when another account already holds the name.

## Verified

- Backend: 24 route tests pass, covering the 409 taken case and the 400 length case.
- UI driven headless: no-jump edit, greyed unselectable authcate, inline taken error, and a clean single-toast save with navigation.

## Notes on #292

- This adds the app-level guard, the path users hit through the profile edit.
- #292 still needs a unique index, default-username collision handling in the pre-save hook, and deduping existing usernames. The index needs a data migration first, so it stays out of this PR.

Closes #289
#292
