### PR TITLE
Enforce conventional commits with a commit-msg hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Enforce Conventional Commits on the commit subject line.
+# https://www.conventionalcommits.org
+#
+# Enabled per-clone via `git config core.hooksPath .githooks` (run `make hooks`,
+# which `make install` does for you).
+
+subject="$(head -n1 "$1")"
+
+# Let git-generated commits (merge/revert) and fixup/squash commits through.
+case "$subject" in
+  "Merge "*|"Revert "*|fixup!*|squash!*) exit 0 ;;
+esac
+
+pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9 ._/-]+\))?!?: .+'
+
+if printf '%s' "$subject" | grep -Eq "$pattern"; then
+  exit 0
+fi
+
+echo "✗ Commit message is not a Conventional Commit." >&2
+echo >&2
+echo "  format: <type>[(scope)][!]: <subject>" >&2
+echo "  types:  feat fix docs style refactor perf test build ci chore revert" >&2
+echo "  e.g.    fix(backend): serve compiled JS for Vercel function" >&2
+echo >&2
+echo "  got:    $subject" >&2
+exit 1

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -7,12 +7,12 @@
 
 subject="$(head -n1 "$1")"
 
-# Let git-generated commits (merge/revert) and fixup/squash commits through.
+# Let git-generated commits (merge/revert) and fixup/squash/amend commits through.
 case "$subject" in
-  "Merge "*|"Revert "*|fixup!*|squash!*) exit 0 ;;
+  "Merge "*|"Revert "*|fixup!*|squash!*|amend!*) exit 0 ;;
 esac
 
-pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9 ._/-]+\))?!?: .+'
+pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9 ._/-]+\))?!?: .+'
 
 if printf '%s' "$subject" | grep -Eq "$pattern"; then
   exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ make rebuild    # docker compose down -v && docker compose up --build -d
 
 1. Create a branch: `git switch -c your-branch-name`
 2. Make your changes and test them.
-3. Commit using [conventional commit messages](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3).
+3. Commit using [conventional commit messages](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3). A `commit-msg` hook enforces this locally — enable it with `make hooks` (or `make install`, which runs it for you).
 4. Open a pull request that describes the change, references related issues, and includes screenshots for UI changes.
 
 Bug fixes, documentation, and performance work are always welcome. For new features, message [@jenul-ferdinand](https://github.com/jenul-ferdinand) first so we can talk it through.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ make rebuild    # docker compose down -v && docker compose up --build -d
 
 1. Create a branch: `git switch -c your-branch-name`
 2. Make your changes and test them.
-3. Commit using [conventional commit messages](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3). A `commit-msg` hook enforces this locally — enable it with `make hooks` (or `make install`, which runs it for you).
+3. Commit using [conventional commit messages](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3). A `commit-msg` hook enforces this locally — enable it with `make hooks` (or `make install`, which runs it for you). Without make, run `git config core.hooksPath .githooks`.
 4. Open a pull request that describes the change, references related issues, and includes screenshots for UI changes.
 
 Bug fixes, documentation, and performance work are always welcome. For new features, message [@jenul-ferdinand](https://github.com/jenul-ferdinand) first so we can talk it through.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-backend dev-frontend install install-backend install-frontend clean help up down logs seed reset-db rebuild test test-backend test-frontend benchmark
+.PHONY: dev dev-backend dev-frontend install install-backend install-frontend hooks clean help up down logs seed reset-db rebuild test test-backend test-frontend benchmark
 
 # Colors for help text
 BLUE := \033[0;34m
@@ -51,7 +51,7 @@ rebuild: ## Full rebuild after dependency changes (removes volumes, reseeds)
 
 ##@ Installation
 
-install: install-backend install-frontend ## Install dependencies for both frontend and backend
+install: install-backend install-frontend hooks ## Install dependencies for both frontend and backend
 	@echo "$(GREEN)All dependencies installed successfully!$(NC)"
 
 install-backend: ## Install backend dependencies
@@ -61,6 +61,10 @@ install-backend: ## Install backend dependencies
 install-frontend: ## Install frontend dependencies
 	@echo "$(GREEN)Installing frontend dependencies...$(NC)"
 	cd frontend && npm install
+
+hooks: ## Enable project git hooks (Conventional Commit message check)
+	@git config core.hooksPath .githooks
+	@echo "$(BLUE)Git hooks enabled (.githooks)$(NC)"
 
 ##@ Testing
 


### PR DESCRIPTION
## Why
The `commit-msg` hook lived only on `develop`, which sat 177 commits behind main and never merged. This branch carries the hook over so we can drop `develop`.

## What this adds
- `.githooks/commit-msg`: a POSIX sh hook that rejects subjects which aren't Conventional Commits.
- A `make hooks` target (also run by `make install`) that enables it via `core.hooksPath`.
- A CONTRIBUTING note pointing contributors at it, plus a no-make fallback.

Each clone opts in. Nothing changes for anyone who skips `make hooks`.

## Verification
I ran the hook against 16 messages, 10 valid and 6 invalid. All 16 classified correctly, including uppercase scopes (`fix(Vercel):`), breaking-change markers (`feat!:`), and the `amend!`/`fixup!`/merge/revert pass-throughs. It checks the subject line only, not the body or footer.

`develop` is already deleted; this branch holds the only copy of the hook until it merges.
