### PR TITLE
Send credentials on authed requests so login persists in dev

### DIFF
--- a/frontend/src/app/shared/services/api/notification.service.spec.ts
+++ b/frontend/src/app/shared/services/api/notification.service.spec.ts
@@ -1,0 +1,31 @@
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../../environments/environment';
+import { NotificationService } from './notification.service';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+  let httpMock: HttpTestingController;
+  const v2 = environment.apiV2Url;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(NotificationService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it("sends credentials when fetching a user's notifications", () => {
+    service.getByUser('u1').subscribe();
+    const req = httpMock.expectOne(`${v2}/notifications/user/u1`);
+    expect(req.request.withCredentials).toBeTrue();
+    req.flush([]);
+  });
+});

--- a/frontend/src/app/shared/services/api/notification.service.ts
+++ b/frontend/src/app/shared/services/api/notification.service.ts
@@ -15,7 +15,8 @@ export class NotificationService {
 
   getByUser(userId: string): Observable<Notification[]> {
     return this.http.get<Notification[]>(
-      `${this.url}/notifications/user/${userId}`
+      `${this.url}/notifications/user/${userId}`,
+      { withCredentials: true }
     );
   }
 

--- a/frontend/src/app/shared/services/api/user.service.spec.ts
+++ b/frontend/src/app/shared/services/api/user.service.spec.ts
@@ -71,6 +71,18 @@ describe('UserService session state', () => {
     expect(service.currentUserValue).toBeNull();
   });
 
+  it('sends credentials on authed reads and updates', () => {
+    service.me().subscribe();
+    const meReq = httpMock.expectOne(`${v2}/users/me`);
+    expect(meReq.request.withCredentials).toBeTrue();
+    meReq.flush(user);
+
+    service.updateUsername('u1', 'newname').subscribe();
+    const updateReq = httpMock.expectOne(`${v2}/users/update/u1`);
+    expect(updateReq.request.withCredentials).toBeTrue();
+    updateReq.flush({ message: 'ok', username: 'newname' });
+  });
+
   it('clearSession drops the user without a backend call', () => {
     service.validateSession().subscribe();
     httpMock

--- a/frontend/src/app/shared/services/api/user.service.ts
+++ b/frontend/src/app/shared/services/api/user.service.ts
@@ -120,7 +120,7 @@ export class UserService {
 
   me(): Observable<IUser> {
     return this.http
-      .get<IUser>(`${this.url}/me`)
+      .get<IUser>(`${this.url}/me`, { withCredentials: true })
       .pipe(tap((user) => this._currentUser.next(user)));
   }
 
@@ -132,7 +132,8 @@ export class UserService {
     return this.http
       .put<{ message: string; username: string }>(
         `${this.url}/update/${userId}`,
-        { username }
+        { username },
+        { withCredentials: true }
       )
       .pipe(
         map((res) => res.username),


### PR DESCRIPTION
## What

- In local dev the frontend (localhost:4200) and API (localhost:8080) are different origins, so the browser only attaches auth cookies to requests that set withCredentials.
- Three authed requests omitted it: [getByUser](https://github.com/wiredmonash/monstar/blob/fix-dev-session-credentials/frontend/src/app/shared/services/api/notification.service.ts#L16-L21), [me](https://github.com/wiredmonash/monstar/blob/fix-dev-session-credentials/frontend/src/app/shared/services/api/user.service.ts#L121-L125), and [updateUsername](https://github.com/wiredmonash/monstar/blob/fix-dev-session-credentials/frontend/src/app/shared/services/api/user.service.ts#L131-L145).
- This adds withCredentials: true to all three, matching the per-call convention the other services already use.

## Why it logged you out

- The notifications popup calls getByUser the moment login populates currentUser$.
- In dev that request carried no cookie and returned 401.
- The auth interceptor refreshed, retried without credentials, hit another 401, and its catchError ran clearSession(), dropping the user right after login.

## Why prod was unaffected

- Prod serves the API same-origin (relative /api/v2), so cookies ride along without the flag. The gap only shows on dev's cross-origin setup.

## Tests

- New assertions that getByUser, me, and updateUsername each send withCredentials. They fail without the fix.

Closes #297
